### PR TITLE
Add gzip compression to node static server

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "bootstrap": "4.0.0-alpha.6",
+    "compression": "^1.6.2",
     "express": "^4.14.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -2,6 +2,7 @@
 // Would be preferrable to replace with apache.
 
 const express = require('express');
+const compression = require('compression');
 const path = require('path');
 
 const app = express();
@@ -13,6 +14,7 @@ function forceHttps(request, response, next) {
   return next();
 }
 
+app.use(compression());
 app.use(forceHttps);
 app.use(express.static(path.join(__dirname, '..', 'build')));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,7 +1329,7 @@ compressible@~2.0.8:
   dependencies:
     mime-db ">= 1.24.0 < 2"
 
-compression@^1.5.2:
+compression, compression@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.6.2.tgz#cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3"
   dependencies:


### PR DESCRIPTION
For example, main.js goes from 300kb to 80kb.