### PR TITLE
Route requests through a proxy instead of using CORS in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ are defined in translation files and consumed using `retranslate`.
 
 ## Development
 
-Use `yarn` or `npm install` to install dependencies. Then use `yarn develop` or `npm run develop` to run the local test environment. It expects `onboarding-service` to be running on port 9000. On local development, CORS is not used, but instead requests are proxied to the service. To run tests, use `yarn test` or `npm test`. On the live environment, CORS is used instead of a proxy.
+Use `yarn` or `npm install` to install dependencies. Then use `yarn develop` or `npm run develop` to run the local test environment. It expects `onboarding-service` to be running on port 9000. To run tests, use `yarn test` or `npm test`. On the live environment, requests to the api are routed through the proxy running in the static server.
 
 ### Production and deployment
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "downloadjs": "^1.4.7",
     "exports-loader": "^0.6.4",
     "express": "^4.14.1",
+    "express-http-proxy": "^0.11.0",
     "hwcrypto-js": "ErkoRisthein/hwcrypto.js",
     "imports-loader": "^0.7.1",
     "raven-js": "^3.12.1",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -18,7 +18,7 @@ function forceHttps(request, response, next) {
 app.use(compression());
 app.use(forceHttps);
 app.use(express.static(path.join(__dirname, '..', 'build')));
-app.use('/api', proxy('onboarding-service.tuleva.ee'));
+app.use('/api', proxy('https://onboarding-service.tuleva.ee'));
 
 app.get('*', (request, response) =>
   response.sendFile(path.join(__dirname, '..', 'build', 'index.html')));

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,7 +1,8 @@
-// This script is used to serve the built files in production.
+// This script is used to serve the built files in production and proxy api requests to the service.
 // Would be preferrable to replace with apache.
 
 const express = require('express');
+const proxy = require('express-http-proxy');
 const compression = require('compression');
 const path = require('path');
 
@@ -17,9 +18,10 @@ function forceHttps(request, response, next) {
 app.use(compression());
 app.use(forceHttps);
 app.use(express.static(path.join(__dirname, '..', 'build')));
+app.use('/api', proxy('onboarding-service.tuleva.ee'));
 
 app.get('*', (request, response) =>
   response.sendFile(path.join(__dirname, '..', 'build', 'index.html')));
 
 const port = process.env.PORT || 8080;
-app.listen(port, () => console.log(`Static files server running on ${port}`)); // eslint-disable-line
+app.listen(port, () => console.log(`Static server running on ${port}`)); // eslint-disable-line

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -1,8 +1,10 @@
 import { downloadFile, get, post, postForm, put } from './http';
 
-const API_URL = 'https://onboarding-service.tuleva.ee';
+const API_URL = '/api';
 
 function getEndpoint(endpoint) {
+  // in production, we proxy through a proxy endpoint at /proxy.
+  // in development, we proxy through webpack dev server without the prefix.
   if (process.env.NODE_ENV === 'production') {
     return `${API_URL}${endpoint}`;
   }

--- a/src/common/http.js
+++ b/src/common/http.js
@@ -51,8 +51,7 @@ export function get(url, params = {}, headers = {}) {
   return fetch(`${url}${urlParameters ? `?${urlParameters}` : ''}`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'text/plain', // for Firefox CORS:
-      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS?redirectlocale=en-US&redirectslug=HTTP_access_control#Simple_requests
+      'Content-Type': 'application/json; charset=utf-8',
       ...headers,
       ...createStatisticsHeaders(),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,10 @@ bytes@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"
 
+bytes@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1827,6 +1831,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
+es6-promise@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+
 es6-set@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.4.tgz#9516b6761c2964b92ff479456233a247dc707ce8"
@@ -2112,6 +2120,13 @@ express, express@^4.13.3:
     type-is "~1.6.14"
     utils-merge "1.0.0"
     vary "~1.1.0"
+
+express-http-proxy:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/express-http-proxy/-/express-http-proxy-0.11.0.tgz#f2e6ba2e9e8677b1ba335375c3cae670d5a1bb0a"
+  dependencies:
+    es6-promise "^3.2.1"
+    raw-body "^2.1.7"
 
 extend@~3.0.0:
   version "3.0.0"
@@ -2637,7 +2652,7 @@ hwcrypto-js@ErkoRisthein/hwcrypto.js:
   version "0.0.11"
   resolved "https://codeload.github.com/ErkoRisthein/hwcrypto.js/tar.gz/c5de48e9028f9b0a4e92bb46c8765ceebb3482cb"
 
-iconv-lite@^0.4.13, iconv-lite@~0.4.13:
+iconv-lite@^0.4.13, iconv-lite@~0.4.13, iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -4562,6 +4577,14 @@ raven-js:
   dependencies:
     json-stringify-safe "^5.0.1"
 
+raw-body@^2.1.7:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
+  dependencies:
+    bytes "2.4.0"
+    iconv-lite "0.4.15"
+    unpipe "1.0.0"
+
 raw-loader@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
@@ -5446,7 +5469,7 @@ uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
 
-unpipe@~1.0.0:
+unpipe@~1.0.0, unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 


### PR DESCRIPTION
CORS is too flaky for our use cases, plus has a tangible performance hit, since we practically never do a "simple request". This removes CORS from prod and replaces it with a proxy endpoint in the static server.