### PR TITLE
Hide facebook widget's overflow to avoid broken layout

### DIFF
--- a/src/login/LoginPage.js
+++ b/src/login/LoginPage.js
@@ -58,7 +58,7 @@ export const LoginPage = ({
         </div>
       </div>
       <div className="row">
-        <div className="col-lg-12 text-center">
+        <div className="col-lg-12 text-center fb-widget">
           <FacebookProvider appId="1939240566313354">
             <Like href="http://www.facebook.com/Tuleva.ee" colorScheme="dark" showFaces />
           </FacebookProvider>

--- a/src/login/LoginPage.scss
+++ b/src/login/LoginPage.scss
@@ -12,3 +12,7 @@
     text-decoration: underline;
   }
 }
+
+.fb-widget {
+  overflow: hidden;
+}


### PR DESCRIPTION
Layout on smaller screens breaks because of the width of FB widget:

![20272094_10213747624346945_655196503_n](https://user-images.githubusercontent.com/1334536/28969807-c4aeded6-792e-11e7-948d-de0135b92658.png)

This is also reproducable on any desktop browser by resizing the window basically as narrow as it gets.

This PR adds a quick fix for hiding overflow on that widget to avoid those effects.