### PR TITLE
Show 3rd pillar headings on login page when monthlyThirdPillarContribution and exchangeExistingThirdPillarUnits in query parameters

### DIFF
--- a/src/entries/components/login/LoginPage.js
+++ b/src/entries/components/login/LoginPage.js
@@ -31,6 +31,8 @@ export const LoginPage = ({
   loadingAuthentication,
   loadingUserConversion,
   errorDescription,
+  monthlyThirdPillarContribution,
+  exchangeExistingThirdPillarUnits,
 }) => (
   <div className="login-page">
     <div className="container pt-5">
@@ -52,6 +54,8 @@ export const LoginPage = ({
                 onIdCodeChange={onIdCodeChange}
                 identityCode={identityCode}
                 onAuthenticateWithIdCard={onAuthenticateWithIdCard}
+                monthlyThirdPillarContribution={monthlyThirdPillarContribution}
+                exchangeExistingThirdPillarUnits={exchangeExistingThirdPillarUnits}
               />
             ) : (
               ''
@@ -100,6 +104,8 @@ LoginPage.defaultProps = {
   loadingAuthentication: false,
   loadingUserConversion: false,
   errorDescription: '',
+  monthlyThirdPillarContribution: null,
+  exchangeExistingThirdPillarUnits: false,
 };
 
 LoginPage.propTypes = {
@@ -116,6 +122,8 @@ LoginPage.propTypes = {
   loadingAuthentication: Types.bool,
   loadingUserConversion: Types.bool,
   errorDescription: Types.string,
+  monthlyThirdPillarContribution: Types.number,
+  exchangeExistingThirdPillarUnits: Types.bool,
 };
 
 const mapStateToProps = state => ({
@@ -125,6 +133,8 @@ const mapStateToProps = state => ({
   loadingAuthentication: state.login.loadingAuthentication,
   loadingUserConversion: state.login.loadingUserConversion,
   errorDescription: state.login.error || state.login.userConversionError,
+  monthlyThirdPillarContribution: state.thirdPillar.monthlyContribution,
+  exchangeExistingThirdPillarUnits: state.thirdPillar.exchangeExistingUnits,
 });
 const mapDispatchToProps = dispatch =>
   bindActionCreators(

--- a/src/entries/components/login/LoginPage.spec.js
+++ b/src/entries/components/login/LoginPage.spec.js
@@ -23,6 +23,8 @@ describe('Login page', () => {
       onIdCodeSubmit: jest.fn(),
       onIdCodeChange: jest.fn(),
       onAuthenticateWithIdCard: jest.fn(),
+      monthlyThirdPillarContribution: 500,
+      exchangeExistingThirdPillarUnits: true,
     };
     component.setProps(formProps);
     expect(component.contains(<LoginForm {...formProps} />)).toBe(true);
@@ -80,6 +82,8 @@ describe('Login page', () => {
       onIdCodeSubmit: jest.fn(),
       onIdCodeChange: jest.fn(),
       onAuthenticateWithIdCard: jest.fn(),
+      monthlyThirdPillarContribution: 500,
+      exchangeExistingThirdPillarUnits: true,
     };
     const authProps = {
       controlCode: null,

--- a/src/entries/components/login/loginForm/LoginForm.js
+++ b/src/entries/components/login/loginForm/LoginForm.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { PropTypes as Types } from 'prop-types';
 import { Message, withTranslations } from 'retranslate';
 
@@ -20,12 +20,37 @@ export const LoginForm = ({
   onIdCodeChange,
   onIdCodeSubmit,
   onAuthenticateWithIdCard,
+  monthlyThirdPillarContribution,
+  exchangeExistingThirdPillarUnits,
 }) => (
   <div className="row mt-4 pt-4 pb-4 justify-content-center login-form">
     <div className="col-lg-9">
-      <h3 className="mt-2 mb-4 pb-2">
-        <Message>login.title</Message>
-      </h3>
+      <div className="mt-2 mb-4">
+        {monthlyThirdPillarContribution ? (
+          <Fragment>
+            <h3 className="mb-4">
+              {exchangeExistingThirdPillarUnits ? (
+                <Message params={{ monthlyContribution: monthlyThirdPillarContribution }}>
+                  login.title.thirdPillar.withExchange
+                </Message>
+              ) : (
+                <Message params={{ monthlyContribution: monthlyThirdPillarContribution }}>
+                  login.title.thirdPillar.withoutExchange
+                </Message>
+              )}
+            </h3>
+
+            <h3>
+              <Message>login.subtitle.thirdPillar</Message>
+            </h3>
+          </Fragment>
+        ) : (
+          <h3>
+            <Message>login.title</Message>
+          </h3>
+        )}
+      </div>
+
       <form onSubmit={runWithDefaultPrevention(() => onPhoneNumberSubmit(phoneNumber))}>
         <div className="form-group">
           <input
@@ -105,6 +130,8 @@ LoginForm.defaultProps = {
 
   phoneNumber: '',
   identityCode: '',
+  monthlyThirdPillarContribution: null,
+  exchangeExistingThirdPillarUnits: false,
 };
 
 LoginForm.propTypes = {
@@ -118,6 +145,8 @@ LoginForm.propTypes = {
 
   phoneNumber: Types.string,
   identityCode: Types.string,
+  monthlyThirdPillarContribution: Types.number,
+  exchangeExistingThirdPillarUnits: Types.bool,
 };
 
 export default withTranslations(LoginForm);

--- a/src/entries/components/login/loginForm/LoginForm.spec.js
+++ b/src/entries/components/login/loginForm/LoginForm.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Message } from 'retranslate';
 
 import { LoginForm } from './LoginForm';
 
@@ -10,6 +11,54 @@ describe('Login form', () => {
   beforeEach(() => {
     props = { translations: { translate: () => '' } };
     component = shallow(<LoginForm {...props} />);
+  });
+
+  it('shows only the default title when no monthly contribution', () => {
+    const componentHas = key => component.contains(<Message>{key}</Message>);
+
+    expect(componentHas('login.title')).toBe(true);
+    expect(componentHas('login.title.thirdPillar.withExchange', { monthlyContribution: 500 })).toBe(
+      false,
+    );
+    expect(
+      componentHas('login.title.thirdPillar.withoutExchange', { monthlyContribution: 500 }),
+    ).toBe(false);
+    expect(componentHas('login.subtitle.thirdPillar')).toBe(false);
+  });
+
+  it('shows the third pillar with exchange title and with subtitle when monthly contribution exists and exchange is requested', () => {
+    component.setProps({
+      monthlyThirdPillarContribution: 500,
+      exchangeExistingThirdPillarUnits: true,
+    });
+
+    const componentHas = (key, params) =>
+      component.contains(<Message params={params}>{key}</Message>);
+
+    expect(componentHas('login.title')).toBe(false);
+    expect(componentHas('login.title.thirdPillar.withExchange', { monthlyContribution: 500 })).toBe(
+      true,
+    );
+    expect(
+      componentHas('login.title.thirdPillar.withoutExchange', { monthlyContribution: 500 }),
+    ).toBe(false);
+    expect(componentHas('login.subtitle.thirdPillar')).toBe(true);
+  });
+
+  it('shows the third pillar with no exchange title and with subtitle when monthly contribution exists and no exchange is requested', () => {
+    component.setProps({ monthlyThirdPillarContribution: 500 });
+
+    const componentHas = (key, params) =>
+      component.contains(<Message params={params}>{key}</Message>);
+
+    expect(componentHas('login.title')).toBe(false);
+    expect(componentHas('login.title.thirdPillar.withExchange', { monthlyContribution: 500 })).toBe(
+      false,
+    );
+    expect(
+      componentHas('login.title.thirdPillar.withoutExchange', { monthlyContribution: 500 }),
+    ).toBe(true);
+    expect(componentHas('login.subtitle.thirdPillar')).toBe(true);
   });
 
   it('changes value of phone number when typed into input', () => {

--- a/src/entries/components/thirdPillar/actions.js
+++ b/src/entries/components/thirdPillar/actions.js
@@ -1,0 +1,5 @@
+import { QUERY_PARAMETERS } from './constants';
+
+export function mapUrlQueryParamsToState(query) {
+  return { type: QUERY_PARAMETERS, query };
+}

--- a/src/entries/components/thirdPillar/actions.spec.js
+++ b/src/entries/components/thirdPillar/actions.spec.js
@@ -1,0 +1,17 @@
+import { mockStore } from '../../../test/utils';
+import { mapUrlQueryParamsToState } from './actions';
+import { QUERY_PARAMETERS } from './constants';
+
+describe('Third pillar actions', () => {
+  it('dispatches query parameters action when mapping query params to state', async () => {
+    const store = mockStore();
+
+    await store.dispatch(mapUrlQueryParamsToState({ aKey: 'aValue', anotherKey: 'anotherValue' }));
+
+    const actions = store.getActions();
+    expect(actions).toContainEqual({
+      type: QUERY_PARAMETERS,
+      query: { aKey: 'aValue', anotherKey: 'anotherValue' },
+    });
+  });
+});

--- a/src/entries/components/thirdPillar/constants.js
+++ b/src/entries/components/thirdPillar/constants.js
@@ -1,0 +1,3 @@
+const withPrefix = name => `@thirdPillar/${name}`;
+
+export const QUERY_PARAMETERS = withPrefix('QUERY_PARAMETERS');

--- a/src/entries/components/thirdPillar/index.js
+++ b/src/entries/components/thirdPillar/index.js
@@ -1,0 +1,5 @@
+import thirdPillarReducer from './reducer';
+import * as actionsModule from './actions';
+
+export const reducer = thirdPillarReducer;
+export const actions = actionsModule;

--- a/src/entries/components/thirdPillar/initialState.js
+++ b/src/entries/components/thirdPillar/initialState.js
@@ -1,0 +1,4 @@
+export default {
+  monthlyContribution: null,
+  exchangeExistingUnits: false,
+};

--- a/src/entries/components/thirdPillar/reducer.js
+++ b/src/entries/components/thirdPillar/reducer.js
@@ -1,0 +1,17 @@
+import { QUERY_PARAMETERS } from './constants';
+import initialState from './initialState';
+
+export default function thirdPillarReducer(state = initialState, action) {
+  const { type, query } = action;
+
+  switch (type) {
+    case QUERY_PARAMETERS:
+      return {
+        ...state,
+        monthlyContribution: parseInt(query.monthlyThirdPillarContribution, 10) || null,
+        exchangeExistingUnits: query.exchangeExistingThirdPillarUnits === 'true',
+      };
+    default:
+      return state;
+  }
+}

--- a/src/entries/components/thirdPillar/reducer.js
+++ b/src/entries/components/thirdPillar/reducer.js
@@ -8,8 +8,10 @@ export default function thirdPillarReducer(state = initialState, action) {
     case QUERY_PARAMETERS:
       return {
         ...state,
-        monthlyContribution: parseInt(query.monthlyThirdPillarContribution, 10) || null,
-        exchangeExistingUnits: query.exchangeExistingThirdPillarUnits === 'true',
+        monthlyContribution:
+          parseInt(query.monthlyThirdPillarContribution, 10) || state.monthlyContribution || null,
+        exchangeExistingUnits:
+          query.exchangeExistingThirdPillarUnits === 'true' || state.exchangeExistingUnits,
       };
     default:
       return state;

--- a/src/entries/components/thirdPillar/reducer.spec.js
+++ b/src/entries/components/thirdPillar/reducer.spec.js
@@ -56,4 +56,23 @@ describe('Third pillar reducer', () => {
 
     expect(state).toEqual({ ...initialState, exchangeExistingUnits: false });
   });
+
+  it('keeps the values in store when no query parameters', () => {
+    const state = reducer(
+      {
+        monthlyContribution: 500,
+        exchangeExistingUnits: true,
+      },
+      {
+        type: QUERY_PARAMETERS,
+        query: {},
+      },
+    );
+
+    expect(state).toEqual({
+      ...initialState,
+      monthlyContribution: 500,
+      exchangeExistingUnits: true,
+    });
+  });
 });

--- a/src/entries/components/thirdPillar/reducer.spec.js
+++ b/src/entries/components/thirdPillar/reducer.spec.js
@@ -1,0 +1,59 @@
+import { QUERY_PARAMETERS } from './constants';
+import initialState from './initialState';
+import reducer from './reducer';
+
+describe('Third pillar reducer', () => {
+  it('saves monthly contribution as a number when monthlyContribution is in query params and parsable as a number', () => {
+    const state = reducer(undefined, {
+      type: QUERY_PARAMETERS,
+      query: { monthlyThirdPillarContribution: '500' },
+    });
+
+    expect(state).toEqual({ ...initialState, monthlyContribution: 500 });
+  });
+
+  it('saves monthly contribution as null when monthlyContribution is in query params and not a number', () => {
+    const state = reducer(undefined, {
+      type: QUERY_PARAMETERS,
+      query: { monthlyThirdPillarContribution: 'f500' },
+    });
+
+    expect(state).toEqual({ ...initialState, monthlyContribution: null });
+  });
+
+  it('saves monthly contribution as null when monthlyContribution is not in query params', () => {
+    const state = reducer(undefined, {
+      type: QUERY_PARAMETERS,
+      query: {},
+    });
+
+    expect(state).toEqual({ ...initialState, monthlyContribution: null });
+  });
+
+  it('saves that existing units should be exchanged when exchangeExistingUnits is the string true in query params', () => {
+    const state = reducer(undefined, {
+      type: QUERY_PARAMETERS,
+      query: { exchangeExistingThirdPillarUnits: 'true' },
+    });
+
+    expect(state).toEqual({ ...initialState, exchangeExistingUnits: true });
+  });
+
+  it('saves that existing units should not be exchanged when exchangeExistingUnits is any other string in query params', () => {
+    const state = reducer(undefined, {
+      type: QUERY_PARAMETERS,
+      query: { exchangeExistingUnits: 'false' },
+    });
+
+    expect(state).toEqual({ ...initialState, exchangeExistingUnits: false });
+  });
+
+  it('saves that existing units should not be exchanged when exchangeExistingUnits is not in query params', () => {
+    const state = reducer(undefined, {
+      type: QUERY_PARAMETERS,
+      query: {},
+    });
+
+    expect(state).toEqual({ ...initialState, exchangeExistingUnits: false });
+  });
+});

--- a/src/entries/components/translations/translations.en.json
+++ b/src/entries/components/translations/translations.en.json
@@ -1,6 +1,8 @@
 {
-
   "login.title": "By logging in you can see your pension account statement and personal rate of return. You can also change your pension fund.",
+  "login.title.thirdPillar.withExchange": "You want to change your III pillar pension fund and make a monthly contribution of {{monthlyContribution}} euros",
+  "login.title.thirdPillar.withoutExchange": "You want to select  III pillar pension fund and make a monthly contribution of {{monthlyContribution}} euros",
+  "login.subtitle.thirdPillar": "Log in and confirm your application with digital signature",
   "login.mobile.id": "Enter with mobile-ID",
   "login.smart.id": "Enter with Smart-ID",
   "login.id.card": "Enter with ID-card",

--- a/src/entries/components/translations/translations.et.json
+++ b/src/entries/components/translations/translations.et.json
@@ -1,6 +1,8 @@
 {
-
   "login.title": "Sisse logides näed oma pensionikonto seisu ja tootlust ning saad soovi korral pensionifondi vahetada.",
+  "login.title.thirdPillar.withExchange": "Soovid oma III samba fondiosakud vahetada ning teha III sambasse sissemakse {{monthlyContribution}} eurot kuus",
+  "login.title.thirdPillar.withoutExchange": "Soovid valida III samba pensionifondi ning teha III sambasse sissemakse {{monthlyContribution}} eurot kuus",
+  "login.subtitle.thirdPillar": "Logi sisse ja kinnita avaldus oma digiallkirjaga",
   "login.mobile.id": "Mobiil-ID",
   "login.smart.id": "Smart-ID",
   "login.id.card": "ID-kaart",

--- a/src/entries/onboarding.js
+++ b/src/entries/onboarding.js
@@ -26,6 +26,10 @@ import LoginPage, { reducer as loginReducer, actions as loginActions } from './c
 import TermsOfUse from './components/termsOfUse';
 import NonMember from './components/newUserFlow/nonMember';
 import { reducer as exchangeReducer, actions as exchangeActions } from './components/exchange';
+import {
+  reducer as thirdPillarReducer,
+  actions as thirdPillarActions,
+} from './components/thirdPillar';
 import trackingReducer from './components/tracking';
 import { reducer as routerReducer, router } from './components/router';
 import { refreshToken } from './components/login/actions';
@@ -54,6 +58,7 @@ const rootReducer = combineReducers({
   exchange: exchangeReducer, // exchage of funds
   account: accountReducer,
   returnComparison: returnComparisonReducer,
+  thirdPillar: thirdPillarReducer,
   tracking: trackingReducer,
   form: formReducer,
   router: routerReducer,
@@ -113,6 +118,7 @@ function applyRouting(nextState) {
   store.dispatch(loginActions.mapUrlQueryParamsToState(nextState.location.query));
   store.dispatch(loginActions.handleIdCardLogin(nextState.location.query));
   store.dispatch(exchangeActions.mapUrlQueryParamsToState(nextState.location.query));
+  store.dispatch(thirdPillarActions.mapUrlQueryParamsToState(nextState.location.query));
   if (router.isRouteToAccount(nextState.location)) {
     store.dispatch(router.routeToAccount());
   }


### PR DESCRIPTION
When applied:
* `monthlyThirdPillarContribution` and`exchangeExistingThirdPillarUnits` query params will be stored in state under `thirdPillar`.
* when `monthlyThirdPillarContribution` is in state on the login page, 3rd pillar specific headings will be shown (also depending on `exchangeExistingThirdPillarUnits`)