### PR TITLE
Show exchange existing units choice only when exchangeable funds exist

### DIFF
--- a/src/entries/components/flows/thirdPillar/ConfirmThirdPillarMandate/ConfirmThirdPillarMandate.js
+++ b/src/entries/components/flows/thirdPillar/ConfirmThirdPillarMandate/ConfirmThirdPillarMandate.js
@@ -17,7 +17,7 @@ export const ConfirmThirdPillarMandate = ({
   signedMandateId,
   monthlyContribution,
   exchangeExistingUnits,
-  sourceFunds,
+  exchangeableSourceFunds,
   selectedFutureContributionsFund,
   agreedToTerms,
   isResident,
@@ -47,7 +47,7 @@ export const ConfirmThirdPillarMandate = ({
         <div className="mt-4">
           <FundTransferTable
             selections={createSelectionsFromFundsToFund(
-              sourceFunds,
+              exchangeableSourceFunds,
               selectedFutureContributionsFund,
             )}
           />
@@ -69,7 +69,7 @@ export const ConfirmThirdPillarMandate = ({
         disabled={!agreedToTerms || isResident === null || isPoliticallyExposed === null}
         onClick={() => {
           onSign(
-            getMandate(sourceFunds, selectedFutureContributionsFund),
+            getMandate(exchangeableSourceFunds, selectedFutureContributionsFund),
             isResident,
             isPoliticallyExposed,
           );
@@ -82,7 +82,7 @@ export const ConfirmThirdPillarMandate = ({
         type="button"
         className="btn btn-secondary mb-2 mr-2"
         onClick={() => {
-          onPreview(getMandate(sourceFunds, selectedFutureContributionsFund));
+          onPreview(getMandate(exchangeableSourceFunds, selectedFutureContributionsFund));
         }}
       >
         <Message>confirmThirdPillarMandate.preview</Message>
@@ -99,27 +99,23 @@ export const ConfirmThirdPillarMandate = ({
 
 function getMandate(sourceFunds, targetFund) {
   return {
-    fundTransferExchanges: sourceFunds
-      .map(sourceFund => ({
-        amount: 1,
-        sourceFundIsin: sourceFund.isin,
-        targetFundIsin: targetFund.isin,
-      }))
-      .filter(({ sourceFundIsin, targetFundIsin }) => sourceFundIsin !== targetFundIsin),
+    fundTransferExchanges: sourceFunds.map(sourceFund => ({
+      amount: 1,
+      sourceFundIsin: sourceFund.isin,
+      targetFundIsin: targetFund.isin,
+    })),
     futureContributionFundIsin: targetFund.isin,
   };
 }
 
 function createSelectionsFromFundsToFund(sourceFunds, targetFund) {
-  return sourceFunds
-    .map(sourceFund => ({
-      sourceFundIsin: sourceFund.isin,
-      sourceFundName: sourceFund.name,
-      targetFundIsin: targetFund.isin,
-      targetFundName: targetFund.name,
-      percentage: 1,
-    }))
-    .filter(({ sourceFundIsin, targetFundIsin }) => sourceFundIsin !== targetFundIsin);
+  return sourceFunds.map(sourceFund => ({
+    sourceFundIsin: sourceFund.isin,
+    sourceFundName: sourceFund.name,
+    targetFundIsin: targetFund.isin,
+    targetFundName: targetFund.name,
+    percentage: 1,
+  }));
 }
 
 const fundType = Types.shape({ isin: Types.string, name: Types.string });
@@ -131,7 +127,7 @@ ConfirmThirdPillarMandate.propTypes = {
   signedMandateId: Types.number,
   monthlyContribution: Types.number,
   exchangeExistingUnits: Types.bool,
-  sourceFunds: Types.arrayOf(fundType),
+  exchangeableSourceFunds: Types.arrayOf(fundType),
   selectedFutureContributionsFund: fundType,
   agreedToTerms: Types.bool,
   isResident: Types.bool,
@@ -147,7 +143,7 @@ ConfirmThirdPillarMandate.defaultProps = {
   signedMandateId: null,
   monthlyContribution: null,
   exchangeExistingUnits: null,
-  sourceFunds: [],
+  exchangeableSourceFunds: [],
   selectedFutureContributionsFund: null,
   agreedToTerms: false,
   isResident: null,
@@ -165,7 +161,7 @@ const mapStateToProps = state => ({
   isResident: state.thirdPillar.isResident,
   isPoliticallyExposed: state.thirdPillar.isPoliticallyExposed,
   monthlyContribution: state.thirdPillar.monthlyContribution,
-  sourceFunds: state.thirdPillar.sourceFunds,
+  exchangeableSourceFunds: state.thirdPillar.exchangeableSourceFunds,
   exchangeExistingUnits: state.thirdPillar.exchangeExistingUnits,
 });
 

--- a/src/entries/components/flows/thirdPillar/ConfirmThirdPillarMandate/ConfirmThirdPillarMandate.spec.js
+++ b/src/entries/components/flows/thirdPillar/ConfirmThirdPillarMandate/ConfirmThirdPillarMandate.spec.js
@@ -67,10 +67,9 @@ describe('ConfirmThirdPillarMandate', () => {
   it('gets mandate preview on preview button click', () => {
     const onPreview = jest.fn();
     component.setProps({
-      sourceFunds: [
+      exchangeableSourceFunds: [
         { isin: 'EE123', name: 'First fund' },
         { isin: 'EE456', name: 'Second fund' },
-        { isin: 'EE789', name: 'Third fund' },
       ],
       selectedFutureContributionsFund: { isin: 'EE789', name: 'Third fund' },
       onPreview,
@@ -92,10 +91,9 @@ describe('ConfirmThirdPillarMandate', () => {
     component.setProps({
       isResident: true,
       isPoliticallyExposed: true,
-      sourceFunds: [
+      exchangeableSourceFunds: [
         { isin: 'EE123', name: 'First fund' },
         { isin: 'EE456', name: 'Second fund' },
-        { isin: 'EE789', name: 'Third fund' },
       ],
       selectedFutureContributionsFund: { isin: 'EE789', name: 'Third fund' },
       onSign,
@@ -125,10 +123,9 @@ describe('ConfirmThirdPillarMandate', () => {
     expect(exchangeTable().exists()).toBe(false);
     component.setProps({
       exchangeExistingUnits: true,
-      sourceFunds: [
+      exchangeableSourceFunds: [
         { isin: 'EE123', name: 'First fund' },
         { isin: 'EE456', name: 'Second fund' },
-        { isin: 'EE789', name: 'Third fund' },
       ],
       selectedFutureContributionsFund: { isin: 'EE789', name: 'Third fund' },
     });

--- a/src/entries/components/flows/thirdPillar/ThirdPillarSetup/ThirdPillarSetup.js
+++ b/src/entries/components/flows/thirdPillar/ThirdPillarSetup/ThirdPillarSetup.js
@@ -10,7 +10,7 @@ import { actions as thirdPillarActions } from '../../../thirdPillar';
 export const ThirdPillarSetup = ({
   monthlyContribution,
   onMonthlyContributionChange,
-  sourceFunds,
+  exchangeableSourceFunds,
   exchangeExistingUnits,
   onExchangeExistingUnitsChange,
   nextPath,
@@ -31,7 +31,7 @@ export const ThirdPillarSetup = ({
       />
     </div>
 
-    {sourceFunds.length > 0 && (
+    {exchangeableSourceFunds.length > 0 && (
       <label
         className="custom-control custom-checkbox mt-3"
         htmlFor="exchange-existing-units-checkbox"
@@ -63,7 +63,7 @@ export const ThirdPillarSetup = ({
 ThirdPillarSetup.propTypes = {
   monthlyContribution: Types.number,
   onMonthlyContributionChange: Types.func,
-  sourceFunds: Types.arrayOf(Types.shape()),
+  exchangeableSourceFunds: Types.arrayOf(Types.shape()),
   exchangeExistingUnits: Types.bool,
   onExchangeExistingUnitsChange: Types.func,
   nextPath: Types.string,
@@ -74,7 +74,7 @@ const noop = () => {};
 ThirdPillarSetup.defaultProps = {
   monthlyContribution: null,
   onMonthlyContributionChange: noop,
-  sourceFunds: [],
+  exchangeableSourceFunds: [],
   exchangeExistingUnits: false,
   onExchangeExistingUnitsChange: noop,
   nextPath: '',
@@ -83,7 +83,7 @@ ThirdPillarSetup.defaultProps = {
 const mapStateToProps = state => ({
   monthlyContribution: state.thirdPillar.monthlyContribution,
   exchangeExistingUnits: state.thirdPillar.exchangeExistingUnits,
-  sourceFunds: state.thirdPillar.sourceFunds,
+  exchangeableSourceFunds: state.thirdPillar.exchangeableSourceFunds,
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/entries/components/flows/thirdPillar/ThirdPillarSetup/ThirdPillarSetup.spec.js
+++ b/src/entries/components/flows/thirdPillar/ThirdPillarSetup/ThirdPillarSetup.spec.js
@@ -27,16 +27,16 @@ describe('ThirdPillarSetup', () => {
     expect(onMonthlyContributionChange).toBeCalledWith(1);
   });
 
-  it('has exchange existing units checkbox when more than one source fund', () => {
+  it('has exchange existing units checkbox when more than one exchangeable source fund', () => {
     const hasCheckbox = () => exchangeExistingUnitsCheckbox().exists();
 
     expect(hasCheckbox()).toBe(false);
-    component.setProps({ sourceFunds: [{ isin: 'EE123' }] });
+    component.setProps({ exchangeableSourceFunds: [{ isin: 'EE123' }] });
     expect(hasCheckbox()).toBe(true);
   });
 
   it('sets exchange existing units checkbox value based on passed prop', () => {
-    component.setProps({ sourceFunds: [{ isin: 'EE123' }] });
+    component.setProps({ exchangeableSourceFunds: [{ isin: 'EE123' }] });
 
     const checked = () => exchangeExistingUnitsCheckbox().prop('checked');
 
@@ -46,7 +46,7 @@ describe('ThirdPillarSetup', () => {
   });
 
   it('calls change handler on exchange existing units change', () => {
-    component.setProps({ sourceFunds: [{ isin: 'EE123' }] });
+    component.setProps({ exchangeableSourceFunds: [{ isin: 'EE123' }] });
 
     const onExchangeExistingUnitsChange = jest.fn();
     component.setProps({ onExchangeExistingUnitsChange });

--- a/src/entries/components/thirdPillar/initialState.js
+++ b/src/entries/components/thirdPillar/initialState.js
@@ -2,7 +2,7 @@ const LHV_INDEX_PLUS_ISIN = 'EE3600109419';
 
 export default {
   monthlyContribution: null,
-  sourceFunds: [],
+  exchangeableSourceFunds: [],
   targetFunds: [],
   selectedFutureContributionsFundIsin: LHV_INDEX_PLUS_ISIN,
   exchangeExistingUnits: false,

--- a/src/entries/components/thirdPillar/reducer.js
+++ b/src/entries/components/thirdPillar/reducer.js
@@ -31,11 +31,14 @@ export default function thirdPillarReducer(state = initialState, action) {
       return { ...state, exchangeExistingUnits: action.exchangeExistingUnits };
     case GET_SOURCE_FUNDS_SUCCESS:
       // eslint-disable-next-line no-case-declarations
-      const sourceFunds = action.sourceFunds.filter(isThirdPillar);
+      const exchangeableSourceFunds = action.sourceFunds
+        .filter(isThirdPillar)
+        .filter(fund => fund.isin !== state.selectedFutureContributionsFundIsin); // TODO: change source funds on selected change
       // eslint-disable-next-line no-case-declarations
-      const exchangeExistingUnits = sourceFunds.length === 0 ? false : state.exchangeExistingUnits;
+      const exchangeExistingUnits =
+        exchangeableSourceFunds.length === 0 ? false : state.exchangeExistingUnits;
 
-      return { ...state, sourceFunds, exchangeExistingUnits };
+      return { ...state, exchangeableSourceFunds, exchangeExistingUnits };
     case GET_TARGET_FUNDS_SUCCESS:
       return {
         ...state,

--- a/src/entries/components/thirdPillar/reducer.spec.js
+++ b/src/entries/components/thirdPillar/reducer.spec.js
@@ -125,8 +125,13 @@ describe('Third pillar reducer', () => {
     });
   });
 
-  it('updates source funds with third pillar funds on success', () => {
-    const state = reducer(undefined, {
+  it('updates source funds with exchangeable third pillar funds on success', () => {
+    const oldState = {
+      ...initialState,
+      selectedFutureContributionsFundIsin: 'EE789',
+    };
+
+    const state = reducer(oldState, {
       type: GET_SOURCE_FUNDS_SUCCESS,
       sourceFunds: [
         { isin: 'EE123', pillar: 3 },
@@ -136,26 +141,29 @@ describe('Third pillar reducer', () => {
     });
 
     expect(state).toEqual({
-      ...initialState,
-      sourceFunds: [{ isin: 'EE123', pillar: 3 }, { isin: 'EE789', pillar: 3 }],
+      ...oldState,
+      exchangeableSourceFunds: [{ isin: 'EE123', pillar: 3 }],
     });
   });
 
-  it('sets exchange existing units to false when no third pillar source funds', () => {
-    const state = reducer(
-      {
-        ...initialState,
-        exchangeExistingUnits: true,
-      },
-      {
-        type: GET_SOURCE_FUNDS_SUCCESS,
-        sourceFunds: [{ isin: 'EE123', pillar: 2 }, { isin: 'EE456', pillar: 2 }],
-      },
-    );
+  it('sets exchange existing units to false when no exchangeable third pillar source funds', () => {
+    const oldState = {
+      ...initialState,
+      exchangeExistingUnits: true,
+      selectedFutureContributionsFundIsin: 'EE789',
+    };
+
+    const state = reducer(oldState, {
+      type: GET_SOURCE_FUNDS_SUCCESS,
+      sourceFunds: [
+        { isin: 'EE123', pillar: 2 },
+        { isin: 'EE456', pillar: 2 },
+        { isin: 'EE789', pillar: 3 },
+      ],
+    });
 
     expect(state).toEqual({
-      ...initialState,
-      sourceFunds: [],
+      ...oldState,
       exchangeExistingUnits: false,
     });
   });


### PR DESCRIPTION
Previously, we would show the exchange existing units checkbox on the first step of third pillar flow even when the only third pillar source fund is the same as the target fund (currently LHV Index Plus). This PR fixes that.