### PR TITLE
Create Euro component and use instead of formatter

### DIFF
--- a/src/entries/components/account/AccountStatement/AccountStatement.js
+++ b/src/entries/components/account/AccountStatement/AccountStatement.js
@@ -3,8 +3,8 @@ import Types from 'prop-types';
 import { Message } from 'retranslate';
 import sumBy from 'lodash/sumBy';
 
-import { formatAmountForCurrency } from '../../common/utils';
 import Table from '../../common/table';
+import Euro from '../../common/Euro';
 
 const AccountStatement = ({ funds }) => {
   const columns = [
@@ -16,13 +16,13 @@ const AccountStatement = ({ funds }) => {
     {
       title: <Message>overview.table.header.value</Message>,
       dataIndex: 'value',
-      footer: formatAmountForCurrency(getTotalValueOfFunds(funds)),
+      footer: <Euro amount={getTotalValueOfFunds(funds)} />,
     },
   ];
 
   const dataSource = funds.map(({ isin, name, activeFund: isActive, price: value }) => ({
     name: `${name}${isActive ? '*' : ''}`,
-    value: formatAmountForCurrency(value),
+    value: <Euro amount={value} />,
     key: isin,
   }));
 

--- a/src/entries/components/account/AccountStatement/AccountStatement.spec.js
+++ b/src/entries/components/account/AccountStatement/AccountStatement.spec.js
@@ -3,10 +3,7 @@ import { shallow } from 'enzyme';
 import AccountStatement from '.';
 
 import Table from '../../common/table';
-
-jest.mock('../../common/utils', () => ({
-  formatAmountForCurrency: value => value,
-}));
+import Euro from '../../common/Euro';
 
 describe('Account statement', () => {
   let component;
@@ -40,7 +37,7 @@ describe('Account statement', () => {
 
     const { footer } = tableProp('columns')[1];
 
-    expect(footer).toBe(111);
+    expect(footer).toEqual(<Euro amount={111} />);
   });
 
   const tableProp = name => component.find(Table).prop(name);

--- a/src/entries/components/account/MemberCapital/MemberCapital.js
+++ b/src/entries/components/account/MemberCapital/MemberCapital.js
@@ -2,8 +2,8 @@ import React from 'react';
 import Types from 'prop-types';
 import { Message } from 'retranslate';
 
-import { formatAmountForCurrency } from '../../common/utils';
 import Table from '../../common/table';
+import Euro from '../../common/Euro';
 
 const MemberCapital = ({
   value: { capitalPayment, profit, membershipBonus, workCompensation, unvestedWorkCompensation },
@@ -17,8 +17,12 @@ const MemberCapital = ({
     {
       title: <Message>overview.table.header.value</Message>,
       dataIndex: 'value',
-      footer: formatAmountForCurrency(
-        capitalPayment + membershipBonus + profit + unvestedWorkCompensation + workCompensation,
+      footer: (
+        <Euro
+          amount={
+            capitalPayment + membershipBonus + profit + unvestedWorkCompensation + workCompensation
+          }
+        />
       ),
     },
   ];
@@ -26,17 +30,17 @@ const MemberCapital = ({
   const dataSource = [
     {
       instrument: <Message>member.capital.capital.payment</Message>,
-      value: formatAmountForCurrency(capitalPayment),
+      value: <Euro amount={capitalPayment} />,
       key: 'payment',
     },
     {
       instrument: <Message>member.capital.profit</Message>,
-      value: formatAmountForCurrency(profit),
+      value: <Euro amount={profit} />,
       key: 'profit',
     },
     {
       instrument: <Message>member.capital.member.bonus</Message>,
-      value: formatAmountForCurrency(membershipBonus),
+      value: <Euro amount={membershipBonus} />,
       key: 'bonus',
     },
   ];
@@ -44,7 +48,7 @@ const MemberCapital = ({
   if (workCompensation) {
     dataSource.push({
       instrument: <Message>member.capital.work.compensation</Message>,
-      value: formatAmountForCurrency(workCompensation),
+      value: <Euro amount={workCompensation} />,
       key: 'work',
     });
   }
@@ -52,7 +56,7 @@ const MemberCapital = ({
   if (unvestedWorkCompensation) {
     dataSource.push({
       instrument: <Message>member.capital.unvested.work.compensation</Message>,
-      value: formatAmountForCurrency(unvestedWorkCompensation),
+      value: <Euro amount={unvestedWorkCompensation} />,
       key: 'unvestedWork',
     });
   }

--- a/src/entries/components/account/MemberCapital/MemberCapital.spec.js
+++ b/src/entries/components/account/MemberCapital/MemberCapital.spec.js
@@ -3,10 +3,7 @@ import { shallow } from 'enzyme';
 import MemberCapital from '.';
 
 import Table from '../../common/table';
-
-jest.mock('../../common/utils', () => ({
-  formatAmountForCurrency: value => value,
-}));
+import Euro from '../../common/Euro';
 
 describe('Member capital', () => {
   const alwaysExistingKeys = ['payment', 'profit', 'bonus'];
@@ -43,7 +40,7 @@ describe('Member capital', () => {
       />,
     );
 
-    expect(component.find(Table).prop('columns')[1].footer).toBe(11111);
+    expect(component.find(Table).prop('columns')[1].footer).toEqual(<Euro amount={11111} />);
   });
 
   const passedDataKeys = () =>

--- a/src/entries/components/common/Euro/Euro.js
+++ b/src/entries/components/common/Euro/Euro.js
@@ -1,0 +1,11 @@
+import Types from 'prop-types';
+
+import { formatAmountForCurrency } from '../utils';
+
+const Euro = ({ amount }) => formatAmountForCurrency(amount);
+
+Euro.propTypes = {
+  amount: Types.number.isRequired,
+};
+
+export default Euro;

--- a/src/entries/components/common/Euro/index.js
+++ b/src/entries/components/common/Euro/index.js
@@ -1,0 +1,1 @@
+export { default } from './Euro';

--- a/src/entries/components/flows/secondPillar/selectSources/pensionFundTable/fundRow/FundRow.js
+++ b/src/entries/components/flows/secondPillar/selectSources/pensionFundTable/fundRow/FundRow.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { PropTypes as Types } from 'prop-types';
 import { Message } from 'retranslate';
 
-import { formatAmountForCurrency } from '../../../../../common/utils';
+import Euro from '../../../../../common/Euro';
 
-const FundRow = ({ price, currency, name, highlighted, active }) => {
+const FundRow = ({ price, name, highlighted, active }) => {
   const displayName = <Message>{name}</Message>;
-  const displayPrice = formatAmountForCurrency(price, currency);
+  const displayPrice = <Euro amount={price} />;
   return (
     <div className="row tv-table__row py-2">
       <div className="col-12 col-sm">
@@ -25,7 +25,6 @@ const FundRow = ({ price, currency, name, highlighted, active }) => {
 
 FundRow.defaultProps = {
   price: 0,
-  currency: 'EUR',
   name: '',
   highlighted: false,
   active: false,
@@ -33,7 +32,6 @@ FundRow.defaultProps = {
 
 FundRow.propTypes = {
   price: Types.number,
-  currency: Types.string,
   name: Types.oneOfType([Types.node, Types.string]),
   highlighted: Types.bool,
   active: Types.bool,

--- a/src/entries/components/flows/secondPillar/selectSources/pensionFundTable/fundRow/FundRow.spec.js
+++ b/src/entries/components/flows/secondPillar/selectSources/pensionFundTable/fundRow/FundRow.spec.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Message } from 'retranslate';
-
-const mockUtils = jest.genMockFromModule('../../../../../common/utils');
-jest.mock('../../../../../common/utils', () => mockUtils);
+import Euro from '../../../../../common/Euro';
 
 const FundRow = require('./FundRow').default;
 
@@ -11,7 +9,6 @@ describe('Fund row', () => {
   let component;
 
   beforeEach(() => {
-    mockUtils.formatAmountForCurrency = (amount, currency) => `formatted(${amount}, ${currency})`;
     component = shallow(<FundRow />);
   });
 
@@ -42,13 +39,9 @@ describe('Fund row', () => {
   });
 
   it('renders the formatted value of the fund', () => {
-    component.setProps({ price: 1234.56, currency: 'EUR' });
-    expect(component.text()).toContain('formatted(1234.56, EUR)');
-    expect(
-      component.findWhere(
-        node => node.type() === 'div' && node.text() === 'formatted(1234.56, EUR)',
-      ).length,
-    ).toBe(1);
+    component.setProps({ price: 1234.56 });
+    expect(hasElementWithAmount(1234.56)).toBe(true);
+    expect(isElementWithAmountHighlighted(1234.56)).toBe(false);
   });
 
   it('adds a star to the name of an active fund row', () => {
@@ -58,11 +51,13 @@ describe('Fund row', () => {
   });
 
   it('renders the formatted value of a fund, highlighted if component is highlighted', () => {
-    component.setProps({ price: 1234.56, currency: 'EUR', highlighted: true });
-    expect(component.text()).toContain('formatted(1234.56, EUR)');
-    expect(
-      component.findWhere(node => node.type() === 'b' && node.text() === 'formatted(1234.56, EUR)')
-        .length,
-    ).toBe(1);
+    component.setProps({ price: 1234.56, highlighted: true });
+    expect(hasElementWithAmount(1234.56)).toBe(true);
+    expect(isElementWithAmountHighlighted(1234.56)).toBe(true);
   });
+
+  const hasElementWithAmount = amount =>
+    component.containsMatchingElement(<Euro amount={amount} />);
+  const isElementWithAmountHighlighted = amount =>
+    component.find('b').containsMatchingElement(<Euro amount={amount} />);
 });


### PR DESCRIPTION
This means we don't have to mock the previously used `formatAmountForCurrency`, and it aligns better with how we use `retranslate`'s `Message`, which is also a component. It's also easy to test with `toEqual` or `containsMatchingElement`.