### PR TITLE
Add contribution and profit columns to account statements

### DIFF
--- a/src/entries/components/account/AccountStatement/AccountStatement.js
+++ b/src/entries/components/account/AccountStatement/AccountStatement.js
@@ -14,17 +14,33 @@ const AccountStatement = ({ funds }) => {
       footer: <Message>accountStatement.columns.fund.footer</Message>,
     },
     {
+      title: <Message>accountStatement.columns.contributions.title</Message>,
+      dataIndex: 'contributions',
+      footer: <Euro amount={sumBy(funds, 'contributionSum')} />,
+      hideOnMobile: true,
+    },
+    {
+      title: <Message>accountStatement.columns.profit.title</Message>,
+      dataIndex: 'profit',
+      footer: <Euro amount={sumBy(funds, 'profit')} />,
+      hideOnMobile: true,
+    },
+    {
       title: <Message>accountStatement.columns.value.title</Message>,
       dataIndex: 'value',
-      footer: <Euro amount={getTotalValueOfFunds(funds)} />,
+      footer: <Euro amount={sumBy(funds, 'price')} />,
     },
   ];
 
-  const dataSource = funds.map(({ isin, name, activeFund: isActive, price: value }) => ({
-    fund: `${name}${isActive ? '*' : ''}`,
-    value: <Euro amount={value} />,
-    key: isin,
-  }));
+  const dataSource = funds.map(
+    ({ isin, name, activeFund: isActive, contributionSum, profit, price: value }) => ({
+      fund: `${name}${isActive ? '*' : ''}`,
+      contributions: <Euro amount={contributionSum} />,
+      profit: <Euro amount={profit} />,
+      value: <Euro amount={value} />,
+      key: isin,
+    }),
+  );
 
   return (
     <>
@@ -37,16 +53,14 @@ const AccountStatement = ({ funds }) => {
   );
 };
 
-function getTotalValueOfFunds(funds) {
-  return sumBy(funds, 'price');
-}
-
 AccountStatement.propTypes = {
   funds: Types.arrayOf(
     Types.shape({
       isin: Types.string.isRequired,
       name: Types.string.isRequired,
       activeFund: Types.bool,
+      contributionSum: Types.number,
+      profit: Types.number,
       price: Types.number,
     }),
   ).isRequired,

--- a/src/entries/components/account/AccountStatement/AccountStatement.spec.js
+++ b/src/entries/components/account/AccountStatement/AccountStatement.spec.js
@@ -12,9 +12,9 @@ describe('Account statement', () => {
     component = shallow(
       <AccountStatement
         funds={[
-          { isin: 'A1', name: 'A', price: 100 },
-          { isin: 'B2', name: 'B', price: 10, activeFund: true },
-          { isin: 'C3', name: 'C', price: 1 },
+          { isin: 'A1', name: 'A', contributionSum: 0, profit: 0, price: 100 },
+          { isin: 'B2', name: 'B', contributionSum: 0, profit: 0, price: 10, activeFund: true },
+          { isin: 'C3', name: 'C', contributionSum: 0, profit: 0, price: 1 },
         ]}
       />,
     );
@@ -24,13 +24,13 @@ describe('Account statement', () => {
     expect(funds).toEqual(['A', 'B*', 'C']);
   });
 
-  it('passes total as value column footer', () => {
+  it('passes total contributions as contribution column footer', () => {
     component = shallow(
       <AccountStatement
         funds={[
-          { isin: 'A1', name: 'A', price: 100 },
-          { isin: 'B2', name: 'B', price: 10 },
-          { isin: 'C3', name: 'C', price: 1 },
+          { isin: 'A1', name: 'A', contributionSum: 100, profit: 0, price: 0 },
+          { isin: 'B2', name: 'B', contributionSum: 10, profit: 0, price: 0 },
+          { isin: 'C3', name: 'C', contributionSum: 1, profit: 0, price: 0 },
         ]}
       />,
     );
@@ -38,6 +38,38 @@ describe('Account statement', () => {
     const { footer } = tableProp('columns')[1];
 
     expect(footer).toEqual(<Euro amount={111} />);
+  });
+
+  it('passes total profit as profit column footer', () => {
+    component = shallow(
+      <AccountStatement
+        funds={[
+          { isin: 'A1', name: 'A', contributionSum: 0, profit: 200, price: 0 },
+          { isin: 'B2', name: 'B', contributionSum: 0, profit: 20, price: 0 },
+          { isin: 'C3', name: 'C', contributionSum: 0, profit: 2, price: 0 },
+        ]}
+      />,
+    );
+
+    const { footer } = tableProp('columns')[2];
+
+    expect(footer).toEqual(<Euro amount={222} />);
+  });
+
+  it('passes total value as value column footer', () => {
+    component = shallow(
+      <AccountStatement
+        funds={[
+          { isin: 'A1', name: 'A', contributionSum: 0, profit: 0, price: 300 },
+          { isin: 'B2', name: 'B', contributionSum: 0, profit: 0, price: 30 },
+          { isin: 'C3', name: 'C', contributionSum: 0, profit: 0, price: 3 },
+        ]}
+      />,
+    );
+
+    const { footer } = tableProp('columns')[3];
+
+    expect(footer).toEqual(<Euro amount={333} />);
   });
 
   const tableProp = name => component.find(Table).prop(name);

--- a/src/entries/components/common/api.js
+++ b/src/entries/components/common/api.js
@@ -23,6 +23,7 @@ function transformFundBalance(fundBalance) {
     managementFeePercent: (fundBalance.fund.managementFeeRate * 100).toFixed(2).replace(/0+$/, ''),
     pillar: fundBalance.pillar,
     contributionSum: fundBalance.contributionSum,
+    profit: fundBalance.profit,
   };
 }
 

--- a/src/entries/components/common/table/Table.js
+++ b/src/entries/components/common/table/Table.js
@@ -3,21 +3,27 @@ import Types from 'prop-types';
 
 import './Table.scss';
 
+const HIDDEN_ON_MOBILE_CELL_CLASS = 'd-none d-sm-table-cell';
+
 const Table = ({ columns, dataSource }) => (
   <div className="table-container">
     <table className="table">
       <thead>
         <tr>
-          {columns.map(({ dataIndex, title }) => (
-            <th key={dataIndex}>{title}</th>
+          {columns.map(({ dataIndex, title, hideOnMobile }) => (
+            <th key={dataIndex} className={getClass(hideOnMobile)}>
+              {title}
+            </th>
           ))}
         </tr>
       </thead>
       <tbody>
         {dataSource.map(({ key, ...data }) => (
           <tr key={key}>
-            {columns.map(({ dataIndex }) => (
-              <td key={dataIndex}>{data[dataIndex]}</td>
+            {columns.map(({ dataIndex, hideOnMobile }) => (
+              <td key={dataIndex} className={getClass(hideOnMobile)}>
+                {data[dataIndex]}
+              </td>
             ))}
           </tr>
         ))}
@@ -25,8 +31,10 @@ const Table = ({ columns, dataSource }) => (
       {columns.some(({ footer }) => !!footer) && (
         <tfoot>
           <tr>
-            {columns.map(({ dataIndex, footer }) => (
-              <td key={dataIndex}>{footer}</td>
+            {columns.map(({ dataIndex, footer, hideOnMobile }) => (
+              <td key={dataIndex} className={getClass(hideOnMobile)}>
+                {footer}
+              </td>
             ))}
           </tr>
         </tfoot>
@@ -34,6 +42,10 @@ const Table = ({ columns, dataSource }) => (
     </table>
   </div>
 );
+
+function getClass(hideOnMobile) {
+  return hideOnMobile ? HIDDEN_ON_MOBILE_CELL_CLASS : undefined;
+}
 
 Table.propTypes = {
   columns: Types.arrayOf(

--- a/src/entries/components/common/table/Table.spec.js
+++ b/src/entries/components/common/table/Table.spec.js
@@ -28,10 +28,10 @@ describe('Table', () => {
 
     expect(rows()).toHaveLength(2);
 
-    expect(textInPosition(0, 0)).toBe('rose');
-    expect(textInPosition(0, 1)).toBe('red');
-    expect(textInPosition(1, 0)).toBe('violet');
-    expect(textInPosition(1, 1)).toBe('blue');
+    expect(textInBodyCell(0, 0)).toBe('rose');
+    expect(textInBodyCell(0, 1)).toBe('red');
+    expect(textInBodyCell(1, 0)).toBe('violet');
+    expect(textInBodyCell(1, 1)).toBe('blue');
   });
 
   it('renders existing column footers in footer when any exist', () => {
@@ -45,7 +45,7 @@ describe('Table', () => {
       />,
     );
 
-    expect(footer().exists()).toBe(true);
+    expect(foot().exists()).toBe(true);
     expect(footers()).toStrictEqual(['', 'rainbow']);
   });
 
@@ -57,20 +57,52 @@ describe('Table', () => {
       />,
     );
 
-    expect(footer().exists()).toBe(false);
+    expect(foot().exists()).toBe(false);
   });
 
-  const titles = () => component.find('thead tr th').map(node => node.text());
+  it('hides columns with hideOnMobile flag on mobile', () => {
+    component = shallow(
+      <Table
+        columns={[
+          { title: 'Flower', dataIndex: 'flower', footer: 'power', hideOnMobile: true },
+          { title: 'Color', dataIndex: 'color', footer: 'rainbow' },
+        ]}
+        dataSource={[
+          { flower: 'rose', color: 'red', key: 'rose' },
+          { flower: 'violet', color: 'blue', key: 'violet' },
+        ]}
+      />,
+    );
+
+    expect(headCellIsHidden(0)).toBe(true);
+    expect(headCellIsHidden(1)).toBe(false);
+
+    expect(bodyCellIsHidden(0, 0)).toBe(true);
+    expect(bodyCellIsHidden(0, 1)).toBe(false);
+    expect(bodyCellIsHidden(1, 0)).toBe(true);
+    expect(bodyCellIsHidden(1, 1)).toBe(false);
+
+    expect(footCellIsHidden(0)).toBe(true);
+    expect(footCellIsHidden(1)).toBe(false);
+  });
+
+  const isHiddenOnMobile = node => node.hasClass('d-none d-sm-table-cell');
+
+  const headCells = () => component.find('thead tr th');
+  const titles = () => headCells().map(node => node.text());
   const rows = () => component.find('tbody tr');
-  const textInPosition = (rowIndex, cellIndex) =>
+  const headCellIsHidden = index => isHiddenOnMobile(headCells().at(index));
+
+  const bodyCell = (rowIndex, cellIndex) =>
     rows()
       .at(rowIndex)
       .find('td')
-      .at(cellIndex)
-      .text();
-  const footer = () => component.find('tfoot');
-  const footers = () =>
-    footer()
-      .find('tr td')
-      .map(node => node.text());
+      .at(cellIndex);
+  const bodyCellIsHidden = (rowIndex, cellIndex) => isHiddenOnMobile(bodyCell(rowIndex, cellIndex));
+  const textInBodyCell = (rowIndex, cellIndex) => bodyCell(rowIndex, cellIndex).text();
+
+  const foot = () => component.find('tfoot');
+  const footCells = () => foot().find('tr td');
+  const footers = () => footCells().map(node => node.text());
+  const footCellIsHidden = index => isHiddenOnMobile(footCells().at(index));
 });

--- a/src/entries/components/translations/translations.en.json
+++ b/src/entries/components/translations/translations.en.json
@@ -53,6 +53,8 @@
   "accountStatement.secondPillar.heading": "II Pillar",
   "accountStatement.thirdPillar.heading": "III Pillar",
   "accountStatement.columns.fund.title": "Pension fund",
+  "accountStatement.columns.contributions.title": "Contributions",
+  "accountStatement.columns.profit.title": "Profit",
   "accountStatement.columns.value.title": "Value",
   "accountStatement.columns.fund.footer": "Total",
   "accountStatement.activeFundNotice": "* - currently active fund",

--- a/src/entries/components/translations/translations.et.json
+++ b/src/entries/components/translations/translations.et.json
@@ -52,6 +52,8 @@
   "accountStatement.secondPillar.heading": "II Sammas",
   "accountStatement.thirdPillar.heading": "III Sammas",
   "accountStatement.columns.fund.title": "Pensionifond",
+  "accountStatement.columns.contributions.title": "Sissemaksed",
+  "accountStatement.columns.profit.title": "Tulu",
   "accountStatement.columns.value.title": "Väärtus",
   "accountStatement.columns.fund.footer": "Kokku",
   "accountStatement.activeFundNotice": "* - siia lähevad igakuised maksed",


### PR DESCRIPTION
As the semantic tables in the repo are not responsive, we hide the contribution and profit columns on mobile.
For that, a new optional `hideOnMobile` flag is added to the `column` API.

Screenshot:
![image](https://user-images.githubusercontent.com/5443561/63777612-0f893c80-c8ec-11e9-8be1-2a8266382717.png)