### PR TITLE
Refactor http to use TypeScript and http.get to use Axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2664,6 +2664,38 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,6 +1936,11 @@
         "@types/react": "*"
       }
     },
+    "@types/react-global-configuration": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-global-configuration/-/react-global-configuration-1.3.1.tgz",
+      "integrity": "sha512-l0Pj4inG0To3ITE3G0vjPpSShSJBKiLv4gHX+Wx/DYlJAbyXLhxzqKjes0lQIqxA72SXobHidzobgIhlmP0ZMA=="
+    },
     "@types/react-redux": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react-redux": "^7.1.2",
     "@types/react-router-dom": "^4.3.5",
     "array.prototype.find": "^2.1.0",
+    "axios": "^0.19.0",
     "bootstrap": "4.3.1",
     "classnames": "^2.2.6",
     "connected-react-router": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/node": "^12.7.2",
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
+    "@types/react-global-configuration": "^1.3.1",
     "@types/react-redux": "^7.1.2",
     "@types/react-router-dom": "^4.3.5",
     "array.prototype.find": "^2.1.0",

--- a/src/entries/components/common/http.js
+++ b/src/entries/components/common/http.js
@@ -34,9 +34,9 @@ function urlEncodeParameters(params) {
     .join('&');
 }
 
-export function get(url, params = {}, headers = {}) {
+export async function get(url, params = {}, headers = {}) {
   const urlParameters = urlEncodeParameters(params);
-  return fetch(`${url}${urlParameters ? `?${urlParameters}` : ''}`, {
+  const response = await fetch(`${url}${urlParameters ? `?${urlParameters}` : ''}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
@@ -46,21 +46,23 @@ export function get(url, params = {}, headers = {}) {
     mode: 'cors',
     credentials: 'include',
     cache: 'default',
-  }).then(transformResponse);
+  });
+  return transformResponse(response);
 }
 
-export function downloadFile(url, headers = {}) {
-  return fetch(url, {
+export async function downloadFile(url, headers = {}) {
+  const response = await fetch(url, {
     headers: { ...headers, ...createCustomHeaders() },
     method: 'GET',
     credentials: 'include',
     mode: 'cors',
     cache: 'default',
-  }).then(transformFileResponse);
+  });
+  return transformFileResponse(response);
 }
 
-export function post(url, params = {}, headers = {}) {
-  return fetch(url, {
+export async function post(url, params = {}, headers = {}) {
+  const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
@@ -71,12 +73,14 @@ export function post(url, params = {}, headers = {}) {
     credentials: 'include',
     mode: 'cors',
     cache: 'default',
-  }).then(transformResponse);
+  });
+
+  return transformResponse(response);
 }
 
 // TODO: write tests for this
-export function put(url, params = {}, headers = {}) {
-  return fetch(url, {
+export async function put(url, params = {}, headers = {}) {
+  const response = await fetch(url, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
@@ -87,11 +91,12 @@ export function put(url, params = {}, headers = {}) {
     credentials: 'include',
     mode: 'cors',
     cache: 'default',
-  }).then(transformResponse);
+  });
+  return transformResponse(response);
 }
 
-export function patch(url, params = {}, headers = {}) {
-  return fetch(url, {
+export async function patch(url, params = {}, headers = {}) {
+  const response = await fetch(url, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
@@ -102,12 +107,14 @@ export function patch(url, params = {}, headers = {}) {
     credentials: 'include',
     mode: 'cors',
     cache: 'default',
-  }).then(transformResponse);
+  });
+
+  return transformResponse(response);
 }
 
-export function postForm(url, params = {}, headers = {}) {
+export async function postForm(url, params = {}, headers = {}) {
   const body = urlEncodeParameters(params);
-  return fetch(url, {
+  const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -118,11 +125,12 @@ export function postForm(url, params = {}, headers = {}) {
     credentials: 'include',
     mode: 'cors',
     cache: 'default',
-  }).then(transformResponse);
+  });
+  return transformResponse(response);
 }
 
-export function simpleFetch(method, url) {
-  return fetch(url, {
+export async function simpleFetch(method, url) {
+  const response = await fetch(url, {
     method,
     headers: {
       'Content-Type': 'text/plain', // for Firefox CORS:
@@ -131,5 +139,6 @@ export function simpleFetch(method, url) {
     mode: 'cors',
     credentials: 'include',
     cache: 'default',
-  }).then(transformResponse);
+  });
+  return transformResponse(response);
 }

--- a/src/entries/components/common/http.ts
+++ b/src/entries/components/common/http.ts
@@ -1,18 +1,18 @@
 import config from 'react-global-configuration';
 
-function createCustomHeaders() {
+function createCustomHeaders(): Record<string, string> {
   return {
     'Accept-Language': config.get('language'),
   };
 }
 
-function transformResponse(response) {
+function transformResponse(response: Response): Promise<Response> {
   if (response.ok && response.status < 400) {
     return response.json();
   }
   if (response.status >= 400) {
     return response.json().then(data => {
-      const error = {};
+      const error: { status?: number; body?: any } = {};
       error.status = response.status;
       error.body = data;
       throw error;
@@ -21,20 +21,20 @@ function transformResponse(response) {
   throw response;
 }
 
-function transformFileResponse(response) {
+function transformFileResponse(response: Response): Promise<Blob> {
   if (response.ok && response.status < 400) {
     return response.blob();
   }
   throw response;
 }
 
-function urlEncodeParameters(params) {
+function urlEncodeParameters(params: Record<string, string>): string {
   return Object.keys(params)
     .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
     .join('&');
 }
 
-export async function get(url, params = {}, headers = {}) {
+export async function get(url: string, params = {}, headers = {}): Promise<any> {
   const urlParameters = urlEncodeParameters(params);
   const response = await fetch(`${url}${urlParameters ? `?${urlParameters}` : ''}`, {
     method: 'GET',
@@ -50,7 +50,7 @@ export async function get(url, params = {}, headers = {}) {
   return transformResponse(response);
 }
 
-export async function downloadFile(url, headers = {}) {
+export async function downloadFile(url: string, headers = {}): Promise<any> {
   const response = await fetch(url, {
     headers: { ...headers, ...createCustomHeaders() },
     method: 'GET',
@@ -61,7 +61,7 @@ export async function downloadFile(url, headers = {}) {
   return transformFileResponse(response);
 }
 
-export async function post(url, params = {}, headers = {}) {
+export async function post(url: string, params = {}, headers = {}): Promise<any> {
   const response = await fetch(url, {
     method: 'POST',
     headers: {
@@ -79,7 +79,7 @@ export async function post(url, params = {}, headers = {}) {
 }
 
 // TODO: write tests for this
-export async function put(url, params = {}, headers = {}) {
+export async function put(url: string, params = {}, headers = {}): Promise<any> {
   const response = await fetch(url, {
     method: 'PUT',
     headers: {
@@ -95,7 +95,7 @@ export async function put(url, params = {}, headers = {}) {
   return transformResponse(response);
 }
 
-export async function patch(url, params = {}, headers = {}) {
+export async function patch(url: string, params = {}, headers = {}): Promise<any> {
   const response = await fetch(url, {
     method: 'PATCH',
     headers: {
@@ -112,7 +112,7 @@ export async function patch(url, params = {}, headers = {}) {
   return transformResponse(response);
 }
 
-export async function postForm(url, params = {}, headers = {}) {
+export async function postForm(url: string, params = {}, headers = {}): Promise<any> {
   const body = urlEncodeParameters(params);
   const response = await fetch(url, {
     method: 'POST',
@@ -129,7 +129,7 @@ export async function postForm(url, params = {}, headers = {}) {
   return transformResponse(response);
 }
 
-export async function simpleFetch(method, url) {
+export async function simpleFetch(method: string, url: string): Promise<any> {
   const response = await fetch(url, {
     method,
     headers: {

--- a/src/entries/components/common/http.ts
+++ b/src/entries/components/common/http.ts
@@ -1,4 +1,7 @@
+import axios, { AxiosResponse } from 'axios';
 import config from 'react-global-configuration';
+
+axios.defaults.withCredentials = true;
 
 function createCustomHeaders(): Record<string, string> {
   return {
@@ -34,20 +37,20 @@ function urlEncodeParameters(params: Record<string, string>): string {
     .join('&');
 }
 
-export async function get(url: string, params = {}, headers = {}): Promise<any> {
-  const urlParameters = urlEncodeParameters(params);
-  const response = await fetch(`${url}${urlParameters ? `?${urlParameters}` : ''}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      ...headers,
-      ...createCustomHeaders(),
-    },
-    mode: 'cors',
-    credentials: 'include',
-    cache: 'default',
-  });
-  return transformResponse(response);
+export async function get(url: string, params = {}, headers = {}): Promise<AxiosResponse['data']> {
+  try {
+    const response = await axios.get(url, {
+      params,
+      headers: { ...headers, ...createCustomHeaders() },
+    });
+    return response.data;
+  } catch (error) {
+    // eslint-disable-next-line no-throw-literal
+    throw {
+      status: error.response.status,
+      body: error.response.data,
+    };
+  }
 }
 
 export async function downloadFile(url: string, headers = {}): Promise<any> {


### PR DESCRIPTION
Best read commit by commit.

This PR:
* makes http module use `async` and `await`
* makes http module TypeScript
* makes http.get use [axios](https://www.npmjs.com/package/axios)

No idea why the test coverage changes, everything is as covered as before.