### PR TITLE
Add personal return select for II and III pillar

### DIFF
--- a/src/entries/components/account/ReturnComparison/Select/Select.tsx
+++ b/src/entries/components/account/ReturnComparison/Select/Select.tsx
@@ -11,6 +11,7 @@ interface SelectProps {
   selected: any;
   onChange: (...args: any[]) => void;
   translations: { translate: (label: string) => {} };
+  disabled?: boolean;
 }
 
 export const Select: FC<SelectProps> = ({
@@ -18,11 +19,13 @@ export const Select: FC<SelectProps> = ({
   selected,
   onChange,
   translations: { translate },
+  disabled = false,
 }) => (
   <select
     className="custom-select"
     onChange={(event): void => onChange(event.target.value)}
     value={selected}
+    disabled={disabled}
   >
     {options.map(({ value, label }) => (
       <option value={value} key={label}>

--- a/src/entries/components/account/ReturnComparison/api/returnComparison.api.test.ts
+++ b/src/entries/components/account/ReturnComparison/api/returnComparison.api.test.ts
@@ -1,35 +1,36 @@
 import { getReturnComparison } from '.';
 import { get } from '../../../common/http';
 import { getEndpoint } from '../../../common/api';
+import { Key } from './returnComparison.api';
 
 jest.mock('../../../common/http', () => ({ get: jest.fn() }));
 jest.mock('../../../common/api', () => ({ getEndpoint: jest.fn() }));
 
 describe('Return comparison API', () => {
-  it('calls the transformed returns endpoint with date as param and token in header', async () => {
+  it('calls the transformed returns endpoint with date and keys as params and token in header', async () => {
     (getEndpoint as jest.Mock).mockImplementationOnce(url => `/transformed${url}`);
     (get as jest.Mock).mockResolvedValueOnce({ returns: [] });
 
     expect(get).not.toHaveBeenCalled();
-    await getReturnComparison('2019-02-28', 'a-token');
+    await getReturnComparison('2019-02-28', { personalKey: Key.THIRD_PILLAR }, 'a-token');
     expect(get).toHaveBeenCalledWith(
       '/transformed/v1/returns',
-      { from: '2019-02-28' },
+      { from: '2019-02-28', keys: [Key.THIRD_PILLAR, Key.EPI, Key.MARKET] },
       { Authorization: 'Bearer a-token' },
     );
   });
 
-  it('returns return comparison object with second pillar, epi, and market values', async () => {
+  it('returns return comparison object with passed personal pillar, epi, and market values', async () => {
     (get as jest.Mock).mockResolvedValueOnce({
       from: '',
       returns: [
-        { key: 'MARKET', value: 0.0686 },
-        { key: 'EPI', value: 0.0228 },
-        { key: 'SECOND_PILLAR', value: 0.0436 },
+        { key: Key.MARKET, value: 0.0686 },
+        { key: Key.EPI, value: 0.0228 },
+        { key: Key.THIRD_PILLAR, value: 0.0436 },
       ],
     });
 
-    const comparison = await getReturnComparison('', '');
+    const comparison = await getReturnComparison('', { personalKey: Key.THIRD_PILLAR }, '');
     expect(comparison).toStrictEqual({
       personal: 0.0436,
       pensionFund: 0.0228,
@@ -43,7 +44,7 @@ describe('Return comparison API', () => {
       returns: [{ key: 'EPI', value: 0.0228 }],
     });
 
-    const comparison = await getReturnComparison('', '');
+    const comparison = await getReturnComparison('', { personalKey: Key.THIRD_PILLAR }, '');
     expect(comparison).toStrictEqual({
       personal: null,
       pensionFund: 0.0228,


### PR DESCRIPTION
This PR:
* adds personal return select for II and III pillar
* adds disabled selects to prepare for other options to compare returns
* changes loader to not flicker the whole component