### PR TITLE
Fix account summary heading

### DIFF
--- a/src/entries/components/translations/translations.et.json
+++ b/src/entries/components/translations/translations.et.json
@@ -49,7 +49,7 @@
   "select.sources.select.none.subtitle": "Järgmise sammuga saad suunata edasised maksed.",
   "select.sources.select.all.recommended": "Alla 55-aastastele sobib see fond.",
 
-  "accountSummary.heading": "Sinu pensionvara koondeis",
+  "accountSummary.heading": "Sinu pensionvara koondseis",
   "accountSummary.columns.pillar.title": "Pensionivara",
   "accountSummary.columns.pillar.footer": "Kokku",
   "accountSummary.columns.contributions": "Sissemaksed",


### PR DESCRIPTION
Tuleva user sent a notification about a typo in the account summary heading. Fix conducted in the Estonian translation json file. 