### PR TITLE
Indicate negative profit with red color

### DIFF
--- a/src/entries/components/account/AccountSummary/AccountSummary.js
+++ b/src/entries/components/account/AccountSummary/AccountSummary.js
@@ -3,9 +3,8 @@ import { PropTypes as Types } from 'prop-types';
 import { Message } from 'retranslate';
 import sumBy from 'lodash/sumBy';
 
-import Table from '../../common/table';
+import Table, { getProfitClassName } from '../../common/table';
 import Euro from '../../common/Euro';
-import { getProfitClassName } from '../../common/utils';
 
 const AccountSummary = ({
   secondPillarContributions,

--- a/src/entries/components/account/AccountSummary/AccountSummary.js
+++ b/src/entries/components/account/AccountSummary/AccountSummary.js
@@ -5,6 +5,7 @@ import sumBy from 'lodash/sumBy';
 
 import Table from '../../common/table';
 import Euro from '../../common/Euro';
+import { getProfitClassName } from '../../common/utils';
 
 const AccountSummary = ({
   secondPillarContributions,
@@ -59,6 +60,8 @@ const AccountSummary = ({
     });
   }
 
+  const summaryItemProfit = sumBy(summary, summaryItem => summaryItem.profit);
+
   const columns = [
     {
       title: <Message>accountSummary.columns.pillar.title</Message>,
@@ -82,8 +85,8 @@ const AccountSummary = ({
       dataIndex: 'profit',
       hideOnMobile: true,
       footer: (
-        <span className="text-success">
-          <Euro amount={sumBy(summary, summaryItem => summaryItem.profit)} />
+        <span className={getProfitClassName(summaryItemProfit)}>
+          <Euro amount={summaryItemProfit} />
         </span>
       ),
     },
@@ -99,7 +102,7 @@ const AccountSummary = ({
     contributions: <Euro amount={contributions} />,
     subtractions: <Euro amount={subtractions} />,
     profit: (
-      <span className="text-success">
+      <span className={getProfitClassName(profit)}>
         <Euro amount={profit} />
       </span>
     ),

--- a/src/entries/components/account/AccountSummary/AccountSummary.spec.js
+++ b/src/entries/components/account/AccountSummary/AccountSummary.spec.js
@@ -51,9 +51,9 @@ describe('Account summary', () => {
             name: 'A',
             contributions: 100,
             subtractions: 0,
-            profit: 20,
+            profit: -50,
             unavailablePrice: 0,
-            price: 120,
+            price: 50,
           },
           {
             isin: 'B2',
@@ -108,8 +108,8 @@ describe('Account summary', () => {
       </span>,
     );
     expect(dataSource[1].profit).toEqual(
-      <span className="text-success">
-        <Euro amount={34} />
+      <span className="text-danger">
+        <Euro amount={-36} />
       </span>,
     );
     expect(dataSource[2].profit).toEqual(
@@ -118,7 +118,7 @@ describe('Account summary', () => {
       </span>,
     );
     expect(dataSource[0].value).toEqual(<Euro amount={114} />);
-    expect(dataSource[1].value).toEqual(<Euro amount={136} />);
+    expect(dataSource[1].value).toEqual(<Euro amount={66} />);
     expect(dataSource[2].value).toEqual(<Euro amount={6} />);
   });
 

--- a/src/entries/components/common/table/Table.js
+++ b/src/entries/components/common/table/Table.js
@@ -47,6 +47,10 @@ function getClass(hideOnMobile) {
   return hideOnMobile ? HIDDEN_ON_MOBILE_CELL_CLASS : undefined;
 }
 
+export function getProfitClassName(profit) {
+  return profit >= 0 ? 'text-success' : 'text-danger';
+}
+
 Table.propTypes = {
   columns: Types.arrayOf(
     Types.shape({
@@ -63,3 +67,5 @@ Table.propTypes = {
 };
 
 export default Table;
+
+

--- a/src/entries/components/common/table/Table.scss
+++ b/src/entries/components/common/table/Table.scss
@@ -1,3 +1,5 @@
+@import '../../variables';
+
 .table-container {
   width: 100%;
 }
@@ -38,14 +40,13 @@
   text-align: right;
 }
 
-.table td.profit-positive {
-  color: green;
+.table td span.profit-positive {
+  color: $green;
 }
 
-.table td.profit-negative {
-  color: red;
+.table td span.profit-negative {
+  color: $red;
 }
-
 
 .table td:first-child, .table th:first-child {
   text-align: left;

--- a/src/entries/components/common/table/Table.scss
+++ b/src/entries/components/common/table/Table.scss
@@ -1,5 +1,3 @@
-@import '../../variables';
-
 .table-container {
   width: 100%;
 }
@@ -38,14 +36,6 @@
 
 .table td, .table th {
   text-align: right;
-}
-
-.table td span.profit-positive {
-  color: $green;
-}
-
-.table td span.profit-negative {
-  color: $red;
 }
 
 .table td:first-child, .table th:first-child {

--- a/src/entries/components/common/table/index.js
+++ b/src/entries/components/common/table/index.js
@@ -1,2 +1,3 @@
 export { default } from './Table';
 export { default as LegacyTable } from './LegacyTable';
+export { getProfitClassName } from './Table'

--- a/src/entries/components/common/utils.js
+++ b/src/entries/components/common/utils.js
@@ -33,7 +33,3 @@ export function formatLargeAmountForCurrency(amount = 0) {
 export function getTotalFundValue(funds) {
   return (funds || []).reduce((sum, { price }) => sum + price, 0);
 }
-
-export function getProfitClassName(profit) {
-  return profit >= 0 ? 'profit-positive' : 'profit-negative';
-}


### PR DESCRIPTION
I noticed that at the moment a negative profit is displayed with green color, which is visually a bit misleading. I made a small code change that actually uses an existing method for identifying a profit color based on positive/negative number. I've attached screenshots to illustrate the situation now and my proposal:

Now: 

<img width="490" alt="negative_profit_original" src="https://user-images.githubusercontent.com/5418595/95255501-28bc2680-082a-11eb-85b4-c0324d9dda8e.png">

Proposed:

<img width="490" alt="negative_profit_proposed" src="https://user-images.githubusercontent.com/5418595/95255529-340f5200-082a-11eb-8a5c-426a8c648779.png">

Maybe you want to use that :).