### PR TITLE
Fix flow redirects for new react router

### DIFF
--- a/src/entries/components/flows/common/Flow.js
+++ b/src/entries/components/flows/common/Flow.js
@@ -56,7 +56,7 @@ export class Flow extends Component {
             <div className="pb-5 px-col">
               <Switch>
                 <Route path={`${flowPath}/${currentStepPath}`} component={StepComponent} />
-                <Redirect path={`${flowPath}`} to={`${flowPath}/${currentStepPath}`} />
+                <Redirect exact path={`${flowPath}`} to={`${flowPath}/${currentStepPath}`} />
               </Switch>
             </div>
             {!isLastStep && <hr className="mb-4" />}


### PR DESCRIPTION
We upgraded react router, which changed the semantics of path matching on redirects. It wasn't a major version bump, which is why we missed it. It broke the `Flow` component, which we've now fixed by including an `exact` modifier on the redirect.