### PR TITLE
Fix success screen

### DIFF
--- a/src/entries/components/flows/secondPillar/success/Success.js
+++ b/src/entries/components/flows/secondPillar/success/Success.js
@@ -4,7 +4,6 @@ import { Message } from 'retranslate';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import FacebookProvider, { Share } from 'react-facebook';
 
 import { downloadMandate } from '../../../exchange/actions';
 import successImage from './success.svg';
@@ -52,21 +51,6 @@ export const Success = ({
         ) : (
           ''
         )}
-
-        <br />
-        <p className="text-center">
-          <b>
-            <Message>success.share.message</Message>
-          </b>
-        </p>
-
-        <FacebookProvider appId="1939240566313354">
-          <Share href="https://tuleva.ee/fondid/">
-            <button className="btn btn-primary mt-3" type="button">
-              <Message>success.share.cta</Message>
-            </button>
-          </Share>
-        </FacebookProvider>
       </div>
       <h2 className="mt-5">
         <Message>success.view.profile.title</Message>

--- a/src/entries/components/flows/secondPillar/success/Success.spec.js
+++ b/src/entries/components/flows/secondPillar/success/Success.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Message } from 'retranslate';
-import FacebookProvider, { Share } from 'react-facebook';
 import { Redirect } from 'react-router-dom';
 
 import { Success } from './Success';
@@ -70,31 +69,5 @@ describe('Success step', () => {
     expect(onDownloadMandate).not.toHaveBeenCalled();
     component.find('button').first().simulate('click');
     expect(onDownloadMandate).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows facebook share message', () => {
-    expect(
-      component.contains(
-        <p className="text-center">
-          <b>
-            <Message>success.share.message</Message>
-          </b>
-        </p>,
-      ),
-    ).toBe(true);
-  });
-
-  it('shows facebook share button', () => {
-    expect(
-      component.contains(
-        <FacebookProvider appId="1939240566313354">
-          <Share href="https://tuleva.ee/fondid/">
-            <button className="btn btn-primary mt-3" type="button">
-              <Message>success.share.cta</Message>
-            </button>
-          </Share>
-        </FacebookProvider>,
-      ),
-    ).toBe(true);
   });
 });


### PR DESCRIPTION
Upgrading a facebook client broke the page, as the Share button functions differently. After discussing with the team, we decided to instead remove the button as it isn't deemed useful.