### PR TITLE
Fix validation message coming up after login

### DIFF
--- a/src/components/exchange/reducer.js
+++ b/src/components/exchange/reducer.js
@@ -23,7 +23,11 @@ import {
   NO_SIGN_MANDATE_ERROR,
 } from './constants';
 
-import { LOG_OUT } from '../login/constants';
+import {
+  ID_CARD_AUTHENTICATION_SUCCESS,
+  LOG_OUT,
+  MOBILE_AUTHENTICATION_SUCCESS,
+} from '../login/constants';
 import { isTuleva } from '../common/utils';
 
 const initialState = {
@@ -222,6 +226,8 @@ export default function exchangeReducer(state = initialState, action) {
         agreedToTerms: action.agreement,
       };
 
+    case MOBILE_AUTHENTICATION_SUCCESS:
+    case ID_CARD_AUTHENTICATION_SUCCESS:
     case LOG_OUT:
       return initialState;
     case NO_SIGN_MANDATE_ERROR:

--- a/src/components/exchange/reducer.spec.js
+++ b/src/components/exchange/reducer.spec.js
@@ -22,7 +22,11 @@ import {
   SIGN_MANDATE_IN_PROGRESS,
 } from './constants';
 
-import { LOG_OUT } from '../login/constants';
+import {
+  ID_CARD_AUTHENTICATION_SUCCESS,
+  LOG_OUT,
+  MOBILE_AUTHENTICATION_SUCCESS,
+} from '../login/constants';
 
 describe('Exchange reducer', () => {
   it('finishes loading pension data', () => {
@@ -584,40 +588,42 @@ describe('Exchange reducer', () => {
     expect(newState.mandateSigningError).toBe(null);
   });
 
-  it('reverts to initial state when log out', () => {
-    const action = { type: LOG_OUT };
-    const newState = exchangeReducer(
-      {
-        sourceFunds: [{ sourceFund: true }],
-        loadingSourceFunds: true,
-        sourceSelection: '123',
-        sourceSelectionExact: true,
-        targetFunds: [],
-        loadingTargetFunds: true,
-        selectedFutureContributionsFundIsin: '123',
-        error: '123',
-        loadingMandate: true,
-        mandateSigningControlCode: '123',
-        mandateSigningError: '123',
-        signedMandateId: 123,
-        agreedToTerms: true,
-      },
-      action,
-    );
+  it('reverts to initial state when logging out or logging in', () => {
+    [LOG_OUT, MOBILE_AUTHENTICATION_SUCCESS, ID_CARD_AUTHENTICATION_SUCCESS].forEach((type) => {
+      const action = { type };
+      const newState = exchangeReducer(
+        {
+          sourceFunds: [{ sourceFund: true }],
+          loadingSourceFunds: true,
+          sourceSelection: '123',
+          sourceSelectionExact: true,
+          targetFunds: [],
+          loadingTargetFunds: true,
+          selectedFutureContributionsFundIsin: '123',
+          error: '123',
+          loadingMandate: true,
+          mandateSigningControlCode: '123',
+          mandateSigningError: '123',
+          signedMandateId: 123,
+          agreedToTerms: true,
+        },
+        action,
+      );
 
-    expect(newState.sourceFunds).toBe(null);
-    expect(newState.loadingSourceFunds).toBe(false);
-    expect(newState.sourceSelection).toHaveLength(0);
-    expect(newState.sourceSelectionExact).toBe(false);
-    expect(newState.targetFunds).toBe(null);
-    expect(newState.loadingTargetFunds).toBe(false);
-    expect(newState.selectedFutureContributionsFundIsin).toBe(null);
-    expect(newState.error).toBe(null);
+      expect(newState.sourceFunds).toBe(null);
+      expect(newState.loadingSourceFunds).toBe(false);
+      expect(newState.sourceSelection).toHaveLength(0);
+      expect(newState.sourceSelectionExact).toBe(false);
+      expect(newState.targetFunds).toBe(null);
+      expect(newState.loadingTargetFunds).toBe(false);
+      expect(newState.selectedFutureContributionsFundIsin).toBe(null);
+      expect(newState.error).toBe(null);
 
-    expect(newState.loadingMandate).toBe(false);
-    expect(newState.mandateSigningControlCode).toBe(null);
-    expect(newState.mandateSigningError).toBe(null);
-    expect(newState.signedMandateId).toBe(false);
-    expect(newState.agreedToTerms).toBe(false);
+      expect(newState.loadingMandate).toBe(false);
+      expect(newState.mandateSigningControlCode).toBe(null);
+      expect(newState.mandateSigningError).toBe(null);
+      expect(newState.signedMandateId).toBe(false);
+      expect(newState.agreedToTerms).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
How to reproduce:
1. Add a bs invalid access token to your sessionStorage
2. Go straight to /account via url
2. Log in after it throws you to the login page
3. You'll see broken the validation message

Reason this was happening was that the exchange reducer error state comes in _after_ log out has happened and thus does not get reset. We're adding a reset for authentication success as well.