### PR TITLE
Improve third pillar flow button clarity

### DIFF
--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -311,7 +311,7 @@
   "thirdPillarFlow.steps.selectSources.title": "Transfer your III pillar to Tuleva",
   "thirdPillarFlow.steps.address.title": "Insert your contact details",
   "thirdPillarFlow.steps.confirmMandate.title": "Confirm mandate",
-  "thirdPillarFlow.steps.payment.title": "Pay",
+  "thirdPillarFlow.steps.payment.title": "Payment details",
 
   "thirdPillarFlowSetup.text": "This account is in pensions registry, does not cost anything nor brings any obligations to do anything.",
   "thirdPillarFlowSetup.subtext": "Selection mandate activates your pension account and until you decide otherwise, directs your future contributions to selected pension fund.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -286,7 +286,7 @@
   "thirdPillarFlow.steps.selectSources.title": "Too III pensionisammas Tulevasse",
   "thirdPillarFlow.steps.address.title": "Sisesta oma kontaktandmed",
   "thirdPillarFlow.steps.confirmMandate.title": "Kinnita avalduse sisu",
-  "thirdPillarFlow.steps.payment.title": "Maksa",
+  "thirdPillarFlow.steps.payment.title": "Sissemakse info",
 
   "thirdPillarFlowSetup.text": "See on tasuta, asub pensionikeskuses ja ei kohusta sind millekski.",
   "thirdPillarFlowSetup.subtext": "Valikuavaldus aktiveerib pensionikonto ning seni kuni sa pole määranud teisiti, suunab su edasised sissemaksed valitud fondi.",


### PR DESCRIPTION
The previous button "Maksa" confused a lot of users - what does it actually do? Now we clarify we're showing the payment details in the next step.