### PR TITLE
Disable submit button when submitting contact details

### DIFF
--- a/src/components/contact-details/reducer.js
+++ b/src/components/contact-details/reducer.js
@@ -1,20 +1,28 @@
-import { UPDATE_USER_SUCCESS, USER_UPDATED } from '../common/user/constants';
+import { UPDATE_USER_START, UPDATE_USER_SUCCESS, USER_UPDATED } from '../common/user/constants';
 
 export const initialState = {
   updateUserSuccess: false,
+  submitting: false,
 };
 
 export default function accountReducer(state = initialState, action) {
   switch (action.type) {
+    case UPDATE_USER_START:
+      return {
+        ...state,
+        submitting: true,
+      };
     case UPDATE_USER_SUCCESS:
       return {
         ...state,
         updateUserSuccess: true,
+        submitting: false,
       };
     case USER_UPDATED:
       return {
         ...state,
         updateUserSuccess: false,
+        submitting: false,
       };
     default:
       return state;

--- a/src/components/contact-details/reducer.spec.js
+++ b/src/components/contact-details/reducer.spec.js
@@ -1,21 +1,35 @@
-import { UPDATE_USER_SUCCESS, USER_UPDATED } from '../common/user/constants';
+import { UPDATE_USER_START, UPDATE_USER_SUCCESS, USER_UPDATED } from '../common/user/constants';
 
 import accountReducer from './reducer';
 
 describe('Contact detail reducer', () => {
+  it('sets submitting state when starting user update', () => {
+    const action = { type: UPDATE_USER_START };
+    const newState = accountReducer({ submitting: false }, action);
+    expect(newState.submitting).toBe(true);
+  });
+
+  it('sets submitting state when update finished', () => {
+    const action = { type: USER_UPDATED };
+    const newState = accountReducer({ submitting: true }, action);
+    expect(newState.submitting).toBe(false);
+  });
+
+  it('sets submitting state when update success', () => {
+    const action = { type: UPDATE_USER_SUCCESS };
+    const newState = accountReducer({ submitting: true }, action);
+    expect(newState.submitting).toBe(false);
+  });
+
   it('correctly sets user update success to state', () => {
     const action = { type: UPDATE_USER_SUCCESS };
-
     const newState = accountReducer({ updateUserSuccess: false }, action);
-
     expect(newState.updateUserSuccess).toBe(true);
   });
 
   it('removes user update success from state', () => {
     const action = { type: USER_UPDATED };
-
     const newState = accountReducer({ updateUserSuccess: true }, action);
-
     expect(newState.updateUserSuccess).toBe(false);
   });
 });

--- a/src/components/contact-details/updateUserForm/UpdateUserForm.js
+++ b/src/components/contact-details/updateUserForm/UpdateUserForm.js
@@ -438,10 +438,8 @@ export const UpdateUserForm = ({
   </div>
 );
 
-const noop = () => null;
-
 UpdateUserForm.defaultProps = {
-  handleSubmit: noop,
+  handleSubmit: () => null,
   invalid: true,
   submitting: false,
   error: '',
@@ -467,6 +465,7 @@ const mapStateToProps = (state) => ({
   initialValues: state.login.user ? { ...state.login.user } : null,
   updateUserSuccess: state.contactDetails.updateUserSuccess,
   isCountryEstonia: selector(state, 'address.countryCode') === 'EE',
+  submitting: state.contactDetails.submitting,
 });
 
 export default connect(mapStateToProps, null)(translatedForm);

--- a/src/components/contact-details/updateUserForm/UpdateUserForm.spec.js
+++ b/src/components/contact-details/updateUserForm/UpdateUserForm.spec.js
@@ -30,4 +30,24 @@ describe('UpdateUserForm', () => {
     component.setProps({ children });
     expect(component.contains(children)).toBe(true);
   });
+
+  it('disables submit button when form invalid', () => {
+    component.setProps({ invalid: true });
+    expect(component.find('button').prop('disabled')).toBe(true);
+  });
+
+  describe('when form valid', () => {
+    beforeEach(() => {
+      component.setProps({ invalid: false });
+    });
+
+    it('enables the submit button', () => {
+      expect(component.find('button').prop('disabled')).toBe(false);
+    });
+
+    it('disables submit button when submitting already in progress', () => {
+      component.setProps({ submitting: true });
+      expect(component.find('button').prop('disabled')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
This should add some clarity to people saying "the button does nothing" while the back-end might be slow.