### PR TITLE
Add confirm page event

### DIFF
--- a/src/components/common/api.ts
+++ b/src/components/common/api.ts
@@ -145,6 +145,15 @@ export function saveMandateWithToken(mandate: string, token: string): Promise<an
   });
 }
 
+export const createMandateConfirmPageEvent = (pillar: number, token: string): Promise<any> =>
+  post(
+    getEndpoint(`/v1/mandates/createConfirmPageEvent?pillar=${pillar}`),
+    {},
+    {
+      Authorization: `Bearer ${token}`,
+    },
+  );
+
 export async function getMobileIdSignatureChallengeCodeForMandateIdWithToken(
   mandateId: string,
   token: string,

--- a/src/components/exchange/actions.js
+++ b/src/components/exchange/actions.js
@@ -14,6 +14,7 @@ import {
   getSourceFundsWithToken,
   getFunds,
   saveMandateWithToken,
+  createMandateConfirmPageEvent,
 } from '../common/api';
 import {
   CHANGE_AGREEMENT_TO_TERMS,
@@ -343,3 +344,7 @@ export function cancelSigningMandate() {
 export function closeErrorMessages() {
   return { type: NO_SIGN_MANDATE_ERROR };
 }
+
+export const createConfirmPageEvent = ({ pillar }) => (dispatch, getState) => {
+  return createMandateConfirmPageEvent(pillar, getState().login.token);
+};

--- a/src/components/exchange/actions.spec.js
+++ b/src/components/exchange/actions.spec.js
@@ -483,4 +483,12 @@ describe('Exchange actions', () => {
     await signMandate(mandate);
     expect(mockApi.saveMandateWithToken).not.toHaveBeenCalled();
   });
+
+  it('calls createMandateConfirmPageEvent correctly', async () => {
+    mockApi.createMandateConfirmPageEvent = jest.fn(() => Promise.resolve(true));
+    const pillar = 3;
+
+    await createBoundAction(actions.createConfirmPageEvent)({ pillar });
+    expect(mockApi.createMandateConfirmPageEvent).toHaveBeenCalledWith(pillar, 'token');
+  });
 });

--- a/src/components/flows/secondPillar/SecondPillarFlow.test.tsx
+++ b/src/components/flows/secondPillar/SecondPillarFlow.test.tsx
@@ -19,6 +19,7 @@ import {
   userCapitalBackend,
   applicationsBackend,
   smartIdSigningBackend,
+  mandateCreateConfirmPageEventBackend,
 } from '../../../test/backend';
 
 jest.unmock('retranslate');
@@ -49,6 +50,7 @@ beforeEach(async () => {
   returnsBackend(server);
   userCapitalBackend(server);
   applicationsBackend(server);
+  mandateCreateConfirmPageEventBackend(server);
 
   render();
 

--- a/src/components/flows/secondPillar/confirmMandate/ConfirmMandate.js
+++ b/src/components/flows/secondPillar/confirmMandate/ConfirmMandate.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+
 import { PropTypes as Types } from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { Message } from 'retranslate';
@@ -13,6 +14,7 @@ import {
   cancelSigningMandate,
   changeAgreementToTerms,
   closeErrorMessages,
+  createConfirmPageEvent,
 } from '../../../exchange/actions';
 
 import MandateNotFilledAlert from './mandateNotFilledAlert';
@@ -104,7 +106,10 @@ export const ConfirmMandate = ({
   onCancelSigningMandate,
   onChangeAgreementToTerms,
   onCloseErrorMessages,
+  onPageLoad,
 }) => {
+  useEffect(() => onPageLoad({ pillar: 2 }));
+
   if (loading) {
     return <Loader className="align-middle" />;
   }
@@ -239,6 +244,7 @@ ConfirmMandate.defaultProps = {
   onCancelSigningMandate: noop,
   onChangeAgreementToTerms: noop,
   onCloseErrorMessages: noop,
+  onPageLoad: noop,
 };
 
 ConfirmMandate.propTypes = {
@@ -267,6 +273,7 @@ ConfirmMandate.propTypes = {
   onCancelSigningMandate: Types.func,
   onChangeAgreementToTerms: Types.func,
   onCloseErrorMessages: Types.func,
+  onPageLoad: Types.func,
 };
 
 const mapStateToProps = (state) => ({
@@ -291,6 +298,7 @@ const mapDispatchToProps = (dispatch) =>
       onChangeAgreementToTerms: changeAgreementToTerms,
       onCancelSigningMandate: cancelSigningMandate,
       onCloseErrorMessages: closeErrorMessages,
+      onPageLoad: createConfirmPageEvent,
     },
     dispatch,
   );

--- a/src/components/flows/thirdPillar/ConfirmThirdPillarMandate/ConfirmThirdPillarMandate.js
+++ b/src/components/flows/thirdPillar/ConfirmThirdPillarMandate/ConfirmThirdPillarMandate.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Types from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -41,7 +41,10 @@ export const ConfirmThirdPillarMandate = ({
   loadingMandate,
   mandateSigningControlCode,
   mandateSigningError,
+  onPageLoad,
 }) => {
+  useEffect(() => onPageLoad({ pillar: 3 }));
+
   const buttonDisabled =
     !agreedToTerms || !isResident || !(isPoliticallyExposed === false) || !occupation;
   return (
@@ -202,6 +205,7 @@ ConfirmThirdPillarMandate.propTypes = {
   onPreview: Types.func,
   onCancelSigningMandate: Types.func,
   onCloseErrorMessages: Types.func,
+  onPageLoad: Types.func,
 };
 
 ConfirmThirdPillarMandate.defaultProps = {
@@ -229,6 +233,7 @@ ConfirmThirdPillarMandate.defaultProps = {
   onPreview: () => {},
   onCancelSigningMandate: () => {},
   onCloseErrorMessages: () => {},
+  onPageLoad: () => {},
 };
 
 const mapStateToProps = (state) => ({
@@ -264,6 +269,7 @@ const mapDispatchToProps = (dispatch) =>
       onPreview: exchangeActions.previewMandate,
       onCancelSigningMandate: exchangeActions.cancelSigningMandate,
       onCloseErrorMessages: exchangeActions.closeErrorMessages,
+      onPageLoad: exchangeActions.createConfirmPageEvent,
     },
     dispatch,
   );

--- a/src/test/backend.ts
+++ b/src/test/backend.ts
@@ -439,3 +439,11 @@ export function applicationsBackend(server: SetupServerApi): void {
 type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
 };
+
+export function mandateCreateConfirmPageEventBackend(server: SetupServerApi): void {
+  server.use(
+    rest.post('http://localhost/v1/mandates/createConfirmPageEvent', (req, res, ctx) => {
+      return res(ctx.json(true));
+    }),
+  );
+}


### PR DESCRIPTION
Adds an event to record users that reach the confirmation page. We have a huge drop-off of users that don't sign the mandate so this will allow us to find these guys from the database later.

Partner PR to this fellow: https://github.com/TulevaEE/onboarding-service/pull/413