### PR TITLE
Fix cancellation deadline API

### DIFF
--- a/src/components/account/ApplicationSection/ApplicationCards.tsx
+++ b/src/components/account/ApplicationSection/ApplicationCards.tsx
@@ -168,7 +168,7 @@ const BaseApplicationCard: React.FunctionComponent<{
 }> = ({ application, title, children, allowedActions }) => {
   const cancellationUrl = `/applications/${application.id}/cancellation`;
   const isBeforeCancellationDeadline = moment().isSameOrBefore(
-    moment(application.cancellationDeadline),
+    moment(application.details.cancellationDeadline),
     'day',
   );
   const canCancel =

--- a/src/components/account/ApplicationSection/ApplicationSection.test.tsx
+++ b/src/components/account/ApplicationSection/ApplicationSection.test.tsx
@@ -205,7 +205,7 @@ describe('Application section', () => {
     const date = new Date();
     date.setMonth(date.getMonth() + 1);
     const application = transfer2Pillar;
-    application.cancellationDeadline = date.toISOString();
+    application.details.cancellationDeadline = date.toISOString();
     mockApplications([application]);
     render();
 
@@ -218,7 +218,7 @@ describe('Application section', () => {
     const date = new Date();
     date.setFullYear(1995);
     const application = transfer2Pillar;
-    application.cancellationDeadline = date.toISOString();
+    application.details.cancellationDeadline = date.toISOString();
     mockApplications([application]);
     render();
 

--- a/src/components/account/ApplicationSection/fixtures.ts
+++ b/src/components/account/ApplicationSection/fixtures.ts
@@ -5,8 +5,8 @@ export const transfer2Pillar = {
   type: ApplicationType.TRANSFER,
   status: ApplicationStatus.PENDING,
   creationTime: new Date('December 17, 1995 03:24:00').toISOString(),
-  cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
   details: {
+    cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
     sourceFund: {
       fundManager: { id: 5, name: 'Tuleva' },
       isin: 'EE3600109435',
@@ -47,8 +47,8 @@ export const transferPIK = {
   type: ApplicationType.TRANSFER,
   status: ApplicationStatus.PENDING,
   creationTime: new Date('December 17, 1995 03:24:00').toISOString(),
-  cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
   details: {
+    cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
     sourceFund: {
       fundManager: { id: 5, name: 'Tuleva' },
       isin: 'EE3600109435',
@@ -123,8 +123,8 @@ export const earlyWithdrawal = {
   type: ApplicationType.EARLY_WITHDRAWAL,
   status: ApplicationStatus.PENDING,
   creationTime: new Date('December 17, 1995 03:24:00').toISOString(),
-  cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
   details: {
+    cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
     fulfillmentDate: new Date('January 2, 1995 03:24:00').toISOString(),
     depositAccountIBAN: 'EE123123123',
   },
@@ -135,8 +135,8 @@ export const withdrawal = {
   type: ApplicationType.WITHDRAWAL,
   status: ApplicationStatus.PENDING,
   creationTime: new Date('December 17, 1995 03:24:00').toISOString(),
-  cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
   details: {
+    cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
     fulfillmentDate: new Date('January 2, 1995 03:24:00').toISOString(),
     depositAccountIBAN: 'EE123123123',
   },
@@ -147,8 +147,8 @@ export const stopContributions = {
   type: ApplicationType.STOP_CONTRIBUTIONS,
   status: ApplicationStatus.PENDING,
   creationTime: new Date('December 17, 1995 03:24:00').toISOString(),
-  cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
   details: {
+    cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
     stopTime: new Date('December 18, 1995 03:24:00').toISOString(),
     earliestResumeTime: new Date('December 19, 1995 03:24:00').toISOString(),
   },
@@ -159,8 +159,8 @@ export const resumeContributions = {
   type: ApplicationType.RESUME_CONTRIBUTIONS,
   status: ApplicationStatus.PENDING,
   creationTime: new Date('December 17, 1995 03:24:00').toISOString(),
-  cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
   details: {
+    cancellationDeadline: '3000-01-01T23:59:59.999999999Z',
     resumeTime: new Date('December 18, 1995 03:24:00').toISOString(),
   },
 };

--- a/src/components/common/apiModels.ts
+++ b/src/components/common/apiModels.ts
@@ -21,6 +21,7 @@ export type TransferApplication = BaseApplication<
       targetPik: string | null;
       amount: number;
     }[];
+    cancellationDeadline: string;
   }
 >;
 
@@ -29,6 +30,7 @@ export type StopContributionsApplication = BaseApplication<
   {
     stopTime: string;
     earliestResumeTime: string;
+    cancellationDeadline: string;
   }
 >;
 
@@ -36,6 +38,7 @@ export type ResumeContributionsApplication = BaseApplication<
   ApplicationType.RESUME_CONTRIBUTIONS,
   {
     resumeTime: string;
+    cancellationDeadline: string;
   }
 >;
 
@@ -75,7 +78,6 @@ export interface BaseApplication<Type extends ApplicationType, Details> {
   id: number;
   status: ApplicationStatus;
   creationTime: string;
-  cancellationDeadline: string;
 
   type: Type;
   details: Details;


### PR DESCRIPTION
Currently we were never utilizing the cancellation deadline logic, since backend and frontend API's didnt match up. In the backend, cancellation deadline was added to the application details while frontend expected it on the toplevel.

Now we correctly hide the application cancellation button when deadline has passed.