### PR TITLE
Add PIK flow to status box

### DIFF
--- a/src/components/account/statusBox/secondPillarStatusBox/SecondPillarStatusBox.test.tsx
+++ b/src/components/account/statusBox/secondPillarStatusBox/SecondPillarStatusBox.test.tsx
@@ -12,9 +12,10 @@ jest.mock('../../../common/apiHooks', () => ({
 describe('SecondPillarStatusBox', () => {
   let component: ShallowWrapper;
   const props = {
-    conversion: completeSecondPillarconversion,
     loading: false,
+    secondPillar: completeSecondPillarconversion.secondPillar,
     secondPillarFunds: [activeSecondPillar],
+    secondPillarPikNumber: null,
   };
 
   beforeEach(() => {
@@ -31,19 +32,24 @@ describe('SecondPillarStatusBox', () => {
   });
 
   it('renders the withdrawal flow when withdrawal is in progress', () => {
-    component.setProps({ conversion: { secondPillar: { pendingWithdrawal: true } } });
+    component.setProps({ secondPillar: { pendingWithdrawal: true } });
     expect(component).toMatchSnapshot();
   });
 
   it('renders the choice flow when fund selection incomplete', () => {
-    component.setProps({ conversion: { secondPillar: { selectionComplete: false } } });
+    component.setProps({ secondPillar: { selectionComplete: false } });
     expect(component).toMatchSnapshot();
   });
 
   it('renders the transfer flow when fund transfers incomplete', () => {
     component.setProps({
-      conversion: { secondPillar: { transfersComplete: false, selectionComplete: true } },
+      secondPillar: { transfersComplete: false, selectionComplete: true },
     });
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders the PIK flow when fund PIK number present', () => {
+    component.setProps({ secondPillarPikNumber: 'EE1234567' });
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/account/statusBox/secondPillarStatusBox/SecondPillarStatusBox.tsx
+++ b/src/components/account/statusBox/secondPillarStatusBox/SecondPillarStatusBox.tsx
@@ -4,27 +4,25 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import StatusBoxRow from '../statusBoxRow';
 import { usePendingApplications } from '../../../common/apiHooks';
-import {
-  Application,
-  ApplicationType,
-  SourceFund,
-  UserConversion,
-} from '../../../common/apiModels';
+import { Application, ApplicationType, Conversion, SourceFund } from '../../../common/apiModels';
+import { State } from '../../../../types';
 
 interface Props {
-  conversion: UserConversion;
   loading: boolean;
+  secondPillar: Conversion;
   secondPillarFunds: SourceFund[];
+  secondPillarPikNumber: string;
 }
 
-export const SecondPillarStatusBox: React.FunctionComponent<Props> = ({
-  conversion,
-  loading = false,
-  secondPillarFunds = [],
-}) => {
+export const SecondPillarStatusBox: React.FC<Props> = ({
+  loading,
+  secondPillar,
+  secondPillarFunds,
+  secondPillarPikNumber,
+}: Props) => {
   const pendingWithdrawal = usePendingWithdrawalApplication();
 
-  if (conversion.secondPillar.pendingWithdrawal && pendingWithdrawal) {
+  if (secondPillar.pendingWithdrawal && pendingWithdrawal) {
     return (
       <StatusBoxRow
         showAction={!loading}
@@ -38,8 +36,23 @@ export const SecondPillarStatusBox: React.FunctionComponent<Props> = ({
     );
   }
 
+  if (secondPillarPikNumber) {
+    return (
+      <StatusBoxRow
+        showAction={!loading}
+        name={<FormattedMessage id="account.status.choice.pillar.second" />}
+        lines={[
+          <FormattedMessage
+            id="account.status.choice.pillar.second.pik"
+            values={{ secondPillarPikNumber }}
+          />,
+        ]}
+      />
+    );
+  }
+
   const activeFund = secondPillarFunds.find((fund) => fund.activeFund);
-  if (!conversion.secondPillar.selectionComplete || !activeFund) {
+  if (!secondPillar.selectionComplete || !activeFund) {
     const statusMessage = activeFund ? (
       activeFund.name
     ) : (
@@ -59,7 +72,7 @@ export const SecondPillarStatusBox: React.FunctionComponent<Props> = ({
     );
   }
 
-  if (!conversion.secondPillar.transfersComplete) {
+  if (!secondPillar.transfersComplete) {
     return (
       <StatusBoxRow
         showAction={!loading}
@@ -90,16 +103,11 @@ const usePendingWithdrawalApplication = (): Application | undefined =>
       application.type === ApplicationType.EARLY_WITHDRAWAL,
   );
 
-const mapStateToProps = (state: {
-  login: {
-    userConversion: UserConversion;
-    loadingUserConversion: boolean;
-  };
-  exchange: { sourceFunds: SourceFund[] };
-}) => ({
-  conversion: state.login.userConversion,
+const mapStateToProps = (state: State) => ({
   loading: state.login.loadingUserConversion,
+  secondPillar: state.login.userConversion.secondPillar,
   secondPillarFunds: state.exchange.sourceFunds,
+  secondPillarPikNumber: state.login.user.secondPillarPikNumber,
 });
 
 export default connect(mapStateToProps)(SecondPillarStatusBox);

--- a/src/components/account/statusBox/secondPillarStatusBox/__snapshots__/SecondPillarStatusBox.test.tsx.snap
+++ b/src/components/account/statusBox/secondPillarStatusBox/__snapshots__/SecondPillarStatusBox.test.tsx.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SecondPillarStatusBox renders the PIK flow when fund PIK number present 1`] = `
+<StatusBoxRow
+  lines={
+    Array [
+      <Memo(MemoizedFormattedMessage)
+        id="account.status.choice.pillar.second.pik"
+        values={
+          Object {
+            "secondPillarPikNumber": "EE1234567",
+          }
+        }
+      />,
+    ]
+  }
+  name={
+    <Memo(MemoizedFormattedMessage)
+      id="account.status.choice.pillar.second"
+    />
+  }
+  showAction={true}
+/>
+`;
+
 exports[`SecondPillarStatusBox renders the choice flow when fund selection incomplete 1`] = `
 <StatusBoxRow
   lines={

--- a/src/components/common/apiModels.ts
+++ b/src/components/common/apiModels.ts
@@ -131,6 +131,7 @@ export interface User {
   phoneNumber: string;
   memberNumber: number;
   pensionAccountNumber: string;
+  secondPillarPikNumber: string;
   address: Address;
   secondPillarActive: boolean;
   thirdPillarActive: boolean;

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -243,6 +243,7 @@
   "account.status.choice.pillar.second.withdraw": "You are leaving II pillar",
   "account.status.choice.pillar.second.withdraw.cancel": "Cancel application",
   "account.status.choice.pillar.second.transferIncomplete": "You have several pension funds",
+  "account.status.choice.pillar.second.pik": "Pension investment account: {secondPillarPikNumber}",
   "account.status.choice.pillar.third": "III pillar",
   "account.status.choice.pillar.third.missing.action": "Open III pillar",
   "account.status.choice.pillar.third.missing.label": "You have not started your 3rd pillar yet",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -218,6 +218,7 @@
   "account.status.choice.pillar.second.withdraw": "Sa oled lahkumas II sambast",
   "account.status.choice.pillar.second.withdraw.cancel": "Tühista avaldus",
   "account.status.choice.pillar.second.transferIncomplete": "Sa kogud täna mitmes erinevas pensionifondis",
+  "account.status.choice.pillar.second.pik": "Pensioni investeerimiskonto: {secondPillarPikNumber}",
   "account.status.choice.pillar.third": "III sammas",
   "account.status.choice.pillar.third.missing.action": "Ava III sammas",
   "account.status.choice.pillar.third.missing.label": "Sul pole III sammas veel avatud",


### PR DESCRIPTION
Previously we were showing "You don't have a second pillar". Now we're showing that the user has an active PIK account and its number.