### PR TITLE
Show a green third pillar status when funds have been transferred

### DIFF
--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
@@ -7,7 +7,7 @@ import { activeThirdPillar, completeThirdPillarconversion } from '../fixtures';
 describe('ThirdPillarStatusBox', () => {
   let component: ShallowWrapper;
   const props = {
-    conversion: completeThirdPillarconversion,
+    conversion: completeThirdPillarconversion.thirdPillar,
     loading: false,
     sourceFunds: [activeThirdPillar],
     pillarActive: true,
@@ -33,7 +33,7 @@ describe('ThirdPillarStatusBox', () => {
 
   it('renders the "pick tuleva" flow when user has some other fund manager', () => {
     component.setProps({
-      conversion: { thirdPillar: { selectionComplete: false, contribution: { yearToDate: 20 } } },
+      conversion: { selectionComplete: false, contribution: { yearToDate: 20 } },
     });
     expect(component).toMatchSnapshot();
   });
@@ -41,11 +41,9 @@ describe('ThirdPillarStatusBox', () => {
   it('renders the "transfer incomplete" flow when user has several funds', () => {
     component.setProps({
       conversion: {
-        thirdPillar: {
-          transfersComplete: false,
-          selectionComplete: true,
-          contribution: { yearToDate: 20 },
-        },
+        transfersComplete: false,
+        selectionComplete: true,
+        contribution: { yearToDate: 20 },
       },
     });
     expect(component).toMatchSnapshot();
@@ -54,12 +52,10 @@ describe('ThirdPillarStatusBox', () => {
   it('renders the "payment incomplete" flow when funds have not transferred yet', () => {
     component.setProps({
       conversion: {
-        thirdPillar: {
-          paymentComplete: false,
-          transfersComplete: true,
-          selectionComplete: true,
-          contribution: { yearToDate: 20 },
-        },
+        paymentComplete: false,
+        transfersComplete: true,
+        selectionComplete: true,
+        contribution: { yearToDate: 20 },
       },
     });
     expect(component).toMatchSnapshot();

--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
@@ -43,6 +43,7 @@ describe('ThirdPillarStatusBox', () => {
       conversion: {
         transfersComplete: false,
         selectionComplete: true,
+        contribution: { yearToDate: 20 },
       },
     });
     expect(component).toMatchSnapshot();

--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
@@ -43,7 +43,6 @@ describe('ThirdPillarStatusBox', () => {
       conversion: {
         transfersComplete: false,
         selectionComplete: true,
-        contribution: { yearToDate: 20 },
       },
     });
     expect(component).toMatchSnapshot();
@@ -55,7 +54,7 @@ describe('ThirdPillarStatusBox', () => {
         paymentComplete: false,
         transfersComplete: true,
         selectionComplete: true,
-        contribution: { yearToDate: 20 },
+        contribution: { total: 0 },
       },
     });
     expect(component).toMatchSnapshot();

--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.tsx
@@ -66,7 +66,7 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
     );
   }
 
-  if (!conversion.paymentComplete) {
+  if (!conversion.paymentComplete && conversion.contribution.total === 0) {
     return (
       <StatusBoxRow
         showAction={!loading}

--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.tsx
@@ -3,11 +3,12 @@ import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import StatusBoxRow from '../statusBoxRow';
-import { SourceFund, UserConversion } from '../../../common/apiModels';
+import { Conversion, SourceFund } from '../../../common/apiModels';
 import { InfoTooltip } from '../../../common';
+import { State } from '../../../../types';
 
 interface Props {
-  conversion: UserConversion;
+  conversion: Conversion;
   loading: boolean;
   sourceFunds: SourceFund[];
   pillarActive: boolean;
@@ -34,7 +35,7 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
   }
 
   const activeFund = sourceFunds.find((fund) => fund.activeFund)?.name;
-  if (!conversion.thirdPillar.selectionComplete) {
+  if (!conversion.selectionComplete) {
     return (
       <StatusBoxRow
         showAction={!loading}
@@ -48,7 +49,7 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
     );
   }
 
-  if (!conversion.thirdPillar.transfersComplete) {
+  if (!conversion.transfersComplete) {
     return (
       <StatusBoxRow
         showAction={!loading}
@@ -65,7 +66,7 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
     );
   }
 
-  if (!conversion.thirdPillar.paymentComplete) {
+  if (!conversion.paymentComplete) {
     return (
       <StatusBoxRow
         showAction={!loading}
@@ -101,26 +102,17 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
   );
 };
 
-const getPaidThisYearRow = (conversion: UserConversion) => (
+const getPaidThisYearRow = (conversion: Conversion) => (
   <small className="text-muted">
     <FormattedMessage
       id="account.status.yearToDateContribution"
-      values={{ contribution: <b>{conversion.thirdPillar.contribution.yearToDate || 0}</b> }}
+      values={{ contribution: <b>{conversion.contribution.yearToDate || 0}</b> }}
     />
   </small>
 );
 
-type State = {
-  login: {
-    userConversion: UserConversion;
-    loadingUserConversion: boolean;
-    user: { thirdPillarActive: boolean };
-  };
-  thirdPillar: { sourceFunds: SourceFund[] };
-};
-
 const mapStateToProps = (state: State) => ({
-  conversion: state.login.userConversion,
+  conversion: state.login.userConversion.thirdPillar,
   loading: state.login.loadingUserConversion,
   sourceFunds: state.thirdPillar.sourceFunds,
   pillarActive: state.login.user.thirdPillarActive,

--- a/src/components/account/statusBox/thirdPillarStatusBox/__snapshots__/ThirdPillarStatusBox.test.tsx.snap
+++ b/src/components/account/statusBox/thirdPillarStatusBox/__snapshots__/ThirdPillarStatusBox.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`ThirdPillarStatusBox renders the "payment incomplete" flow when funds h
           values={
             Object {
               "contribution": <b>
-                20
+                0
               </b>,
             }
           }

--- a/src/components/thirdPillar/types.ts
+++ b/src/components/thirdPillar/types.ts
@@ -1,8 +1,8 @@
-import { Fund, HttpError } from '../common/apiModels';
+import { Fund, HttpError, SourceFund } from '../common/apiModels';
 
 export type ThirdPillar = {
   monthlyContribution: number;
-  sourceFunds: Fund[];
+  sourceFunds: SourceFund[];
   loadingSourceFunds: boolean;
   loadingTargetFunds: boolean;
   exchangeableSourceFunds: Fund[];


### PR DESCRIPTION
We have customers who have transferred their third pillar to Tuleva and are not planning to add payments. They get worried when we're showing a red X mark with "your funds have not transferred yet", even though they are converted customers.