### PR TITLE
Show numeric keyboard when logging in

### DIFF
--- a/src/components/login/loginForm/LoginForm.js
+++ b/src/components/login/loginForm/LoginForm.js
@@ -169,7 +169,7 @@ const renderSmartId = (onIdCodeSubmit, personalCode, onPersonalCodeChange, forma
         <input
           id="smart-id-personal-code"
           type="number"
-          inputmode="numeric"
+          inputMode="numeric"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"
@@ -204,7 +204,7 @@ const renderMobileId = (
         <input
           id="mobile-id-personal-code"
           type="number"
-          inputmode="numeric"
+          inputMode="numeric"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"

--- a/src/components/login/loginForm/LoginForm.js
+++ b/src/components/login/loginForm/LoginForm.js
@@ -169,6 +169,7 @@ const renderSmartId = (onIdCodeSubmit, personalCode, onPersonalCodeChange, forma
         <input
           id="smart-id-personal-code"
           type="number"
+          inputmode="numeric"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"
@@ -203,6 +204,7 @@ const renderMobileId = (
         <input
           id="mobile-id-personal-code"
           type="number"
+          inputmode="numeric"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"


### PR DESCRIPTION
Show a more finger-friendly numeric keyboard instead of the alphanumeric one when focusing the "Identity code" field, both for Smart-ID and mID.