### PR TITLE
Login fields’ attributes: added autocomplete, changed type

### DIFF
--- a/src/components/login/loginForm/LoginForm.js
+++ b/src/components/login/loginForm/LoginForm.js
@@ -170,7 +170,7 @@ const renderSmartId = (onIdCodeSubmit, personalCode, onPersonalCodeChange, forma
           id="smart-id-personal-code"
           type="text"
           inputMode="numeric"
-          autocomplete="username"
+          autoComplete="username"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"
@@ -206,7 +206,7 @@ const renderMobileId = (
           id="mobile-id-personal-code"
           type="text"
           inputMode="numeric"
-          autocomplete="username"
+          autoComplete="username"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"
@@ -217,7 +217,7 @@ const renderMobileId = (
         <input
           id="mobile-id-number"
           type="tel"
-          autocomplete="tel"
+          autoComplete="tel"
           value={phoneNumber}
           onChange={(event) => onPhoneNumberChange(event.target.value)}
           className="form-control form-control-lg"

--- a/src/components/login/loginForm/LoginForm.js
+++ b/src/components/login/loginForm/LoginForm.js
@@ -168,8 +168,9 @@ const renderSmartId = (onIdCodeSubmit, personalCode, onPersonalCodeChange, forma
       <div className="form-group">
         <input
           id="smart-id-personal-code"
-          type="number"
+          type="text"
           inputMode="numeric"
+          autocomplete="username"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"
@@ -203,8 +204,9 @@ const renderMobileId = (
       <div className="form-group">
         <input
           id="mobile-id-personal-code"
-          type="number"
+          type="text"
           inputMode="numeric"
+          autocomplete="username"
           value={personalCode}
           onChange={(event) => onPersonalCodeChange(event.target.value)}
           className="form-control form-control-lg"
@@ -215,6 +217,7 @@ const renderMobileId = (
         <input
           id="mobile-id-number"
           type="tel"
+          autocomplete="tel"
           value={phoneNumber}
           onChange={(event) => onPhoneNumberChange(event.target.value)}
           className="form-control form-control-lg"


### PR DESCRIPTION
Added autocomplete attributes so that field values could be saved into password managers and later easily filled.

Changed type attribute from 'number' to 'text' for ID code. Is more appropriate in this case and avoids input field with spinner buttons when styles fail to load. (The newly added inputmode attribute will continue to open the correct keyboard on mobile.)