### PR TITLE
Add onboarding guide for direct employer 3rd pillar payments, for public sector employees

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
     {
       files: ['**/*.ts', '**/*.tsx'],
       rules: {
-        '@typescript-eslint/explicit-module-boundary-types': 1, // should only be used once file is renamed to actual typescript
+        '@typescript-eslint/explicit-module-boundary-types': 0, // should only be used once file is renamed to actual typescript
         'no-shadow': 'off', // https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope
         '@typescript-eslint/no-shadow': ['error'],
         'react/react-in-jsx-scope': 'off',

--- a/src/components/LoggedInApp/LoggedInApp.js
+++ b/src/components/LoggedInApp/LoggedInApp.js
@@ -24,7 +24,7 @@ import { TransactionPageThirdPillar } from '../account/TransactionSection/Transa
 import { ContributionPageThirdPillar } from '../contribution/ContributionPageThirdPillar';
 import Gift from '../flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift';
 import ThirdPillarSuccess from '../flows/thirdPillar/ThirdPillarSuccess';
-import EmployerPayment from '../flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails';
+import { EmployerPaymentDetails } from '../flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails';
 import { ContributionPageSecondPillar } from '../contribution/ContributionPageSecondPillar';
 import { TransactionPageSecondPillar } from '../account/TransactionSection/TransactionPageSecondPillar';
 import SecondPillarUpsellCard from '../account/SecondPillarUpsell/SecondPillarUpsellCard';
@@ -101,7 +101,7 @@ export class LoggedInApp extends PureComponent {
               <Route path="/3rd-pillar-payment" component={ThirdPillarPaymentPage} />
               <Route path="/3rd-pillar-success" component={ThirdPillarSuccess} />
               <Route path="/3rd-pillar-gift" component={Gift} />
-              <Route path="/3rd-pillar-employer" component={EmployerPayment} />
+              <Route path="/3rd-pillar-employer" component={EmployerPaymentDetails} />
               <Route path="/2nd-pillar-transactions" component={TransactionPageSecondPillar} />
               <Route path="/3rd-pillar-transactions" component={TransactionPageThirdPillar} />
               <Route path="/2nd-pillar-contributions" component={ContributionPageSecondPillar} />

--- a/src/components/account/GreetingBar/GreetingBar.js
+++ b/src/components/account/GreetingBar/GreetingBar.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Shimmer } from '../../common/shimmer/Shimmer';
+import { getFullName } from '../../common/utils';
 
 export class GreetingBar extends Component {
   componentDidMount() {}
@@ -19,7 +20,7 @@ export class GreetingBar extends Component {
     return (
       <>
         <div className="col-md-auto mb-1 mt-2 lead">
-          <FormattedMessage id="account.greeting" />, {user.firstName} {user.lastName}!
+          <FormattedMessage id="account.greeting" />, {getFullName(user)}!
         </div>
         <div className="col mb-1 mt-2 text-md-right">
           {user.email}

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -1,6 +1,6 @@
-import { FundStatus } from './apiModels';
+import { Fund, FundStatus, SourceFund } from './apiModels';
 
-const isTruthy = (value) => !!value;
+const isTruthy = (value: unknown) => !!value;
 
 const NOT_FOUND_ITEM_CONSTANT = {}; // using this as a secret comparison reference.
 
@@ -18,10 +18,14 @@ export function findWhere(list = [], predicate = isTruthy) {
 }
 
 export function createClamper(lowerLimit = 0, upperLimit = 10) {
-  return (value) => Math.max(Math.min(value, upperLimit), lowerLimit);
+  return (value: number): number => Math.max(Math.min(value, upperLimit), lowerLimit);
 }
 
-export function formatAmountForCurrency(amount = 0, fractionDigits = 2, options = {}) {
+export function formatAmountForCurrency(
+  amount = 0,
+  fractionDigits = 2,
+  options: { isSigned?: boolean } = {},
+) {
   const { isSigned = false } = options;
   const sign = amount > 0 && isSigned ? '+' : '';
   let formattedAmount = amount.toFixed(fractionDigits).replace(/\B(?=(\d{3})+(?!\d))/g, '\u00A0');
@@ -35,12 +39,12 @@ export function formatLargeAmountForCurrency(amount = 0) {
   return `${Math.round(amount).toLocaleString('et-EE')}\u00A0€`; // hardcoded euro until more currencies.
 }
 
-export function getTotalFundValue(funds) {
-  return (funds || []).reduce((sum, { price }) => sum + price, 0);
+export function getTotalFundValue(funds: SourceFund[] = []) {
+  return funds.reduce((sum, { price }) => sum + price, 0);
 }
 
-export const isActive = (fund) => fund.status === FundStatus.ACTIVE;
-export const isSecondPillar = (fund) => fund.pillar === 2;
-export const isThirdPillar = (fund) => fund.pillar === 3;
+export const isActive = (fund: Fund) => fund.status === FundStatus.ACTIVE;
+export const isSecondPillar = (fund: Fund) => fund.pillar === 2;
+export const isThirdPillar = (fund: Fund) => fund.pillar === 3;
 
-export const isTuleva = (fund) => (fund.fundManager || {}).name === 'Tuleva';
+export const isTuleva = (fund: Fund) => (fund.fundManager || {}).name === 'Tuleva';

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -1,4 +1,4 @@
-import { Fund, FundStatus, SourceFund, User } from './apiModels';
+import { Fund, FundStatus, User } from './apiModels';
 
 const isTruthy = (value: unknown) => !!value;
 

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -1,4 +1,4 @@
-import { Fund, FundStatus, SourceFund } from './apiModels';
+import { Fund, FundStatus, SourceFund, User } from './apiModels';
 
 const isTruthy = (value: unknown) => !!value;
 
@@ -42,6 +42,8 @@ export function formatLargeAmountForCurrency(amount = 0) {
 export function getTotalFundValue(funds: SourceFund[] = []) {
   return funds.reduce((sum, { price }) => sum + price, 0);
 }
+
+export const getFullName = (user: User) => `${user.firstName} ${user.lastName}`;
 
 export const isActive = (fund: Fund) => fund.status === FundStatus.ACTIVE;
 export const isSecondPillar = (fund: Fund) => fund.pillar === 2;

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -39,10 +39,6 @@ export function formatLargeAmountForCurrency(amount = 0) {
   return `${Math.round(amount).toLocaleString('et-EE')}\u00A0€`; // hardcoded euro until more currencies.
 }
 
-export function getTotalFundValue(funds: SourceFund[] = []) {
-  return funds.reduce((sum, { price }) => sum + price, 0);
-}
-
 export const getFullName = (user: User) => `${user.firstName} ${user.lastName}`;
 
 export const isActive = (fund: Fund) => fund.status === FundStatus.ACTIVE;

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
@@ -276,12 +276,12 @@ export const Payment: React.FunctionComponent<{
         </>
       )}
       {paymentType === PaymentType.EMPLOYER && (
-        <>
-          <EmployerPaymentDetails />
+        <div className="mt-4 payment-details p-4">
+          <EmployerPaymentDetails /> {/*TODO private only here*/}
           <a className="btn btn-light text-nowrap mt-4" href="/account">
             <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
           </a>
-        </>
+        </div>
       )}
     </>
   );

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
@@ -16,7 +16,7 @@ import { SwedbankRecurringPaymentDetails } from './paymentDetails/SwedbankRecurr
 import { SebRecurringPaymentDetails } from './paymentDetails/SebRecurringPaymentDetails';
 import { LhvRecurringPaymentDetails } from './paymentDetails/LhvRecurringPaymentDetails';
 import { CoopRecurringPaymentDetails } from './paymentDetails/CoopRecurringPaymentDetails';
-import EmployerPayment from './paymentDetails/EmployerPaymentDetails';
+import { EmployerPaymentDetails } from './paymentDetails/EmployerPaymentDetails';
 
 export const Payment: React.FunctionComponent<{
   personalCode: string;
@@ -277,7 +277,7 @@ export const Payment: React.FunctionComponent<{
       )}
       {paymentType === PaymentType.EMPLOYER && (
         <>
-          <EmployerPayment />
+          <EmployerPaymentDetails />
           <a className="btn btn-light text-nowrap mt-4" href="/account">
             <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
           </a>

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarPaymentPage.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarPaymentPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { State } from '../../../../types';
-import Payment from './Payment'; // eslint-disable-line import/no-named-as-default
+import { Payment } from './Payment';
 import { getAuthentication } from '../../../common/authenticationManager';
 
 export const PaymentPage: React.FunctionComponent<{

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarPaymentStep.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarPaymentStep.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { State } from '../../../../types';
-import Payment from './Payment'; // eslint-disable-line import/no-named-as-default
+import { Payment } from './Payment';
 
 export const ThirdPillarPaymentStep: React.FunctionComponent<{
   previousPath: string;

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.spec.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.spec.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { setupServer } from 'msw/node';
-import { act, screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
 import userEvent from '@testing-library/user-event';
@@ -68,15 +67,11 @@ describe('When a user is setting up third pillar payments via employer', () => {
     const publicOption = await publicSectorOption();
     const privateOption = await privateSectorOption();
 
-    act(() => {
-      userEvent.click(publicOption);
-    });
+    userEvent.click(publicOption);
     expect(await publicSectorOption()).toBeChecked();
     expect(await navigateToRtkFormButton()).toBeVisible();
 
-    act(() => {
-      userEvent.click(privateOption);
-    });
+    userEvent.click(privateOption);
     expect(await privateSectorOption()).toBeChecked();
     expect(await saveApplicationFormButton()).toBeVisible();
   });
@@ -131,9 +126,7 @@ describe('When a user is setting up third pillar payments via employer', () => {
 
       const publicOption = await publicSectorOption();
 
-      act(() => {
-        userEvent.click(publicOption);
-      });
+      userEvent.click(publicOption);
       expect(await publicSectorOption()).toBeChecked();
 
       expect(await screen.findByText('Digitally sign the application in RTK.'));

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.spec.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.spec.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { setupServer } from 'msw/node';
+import { act, screen, waitFor } from '@testing-library/react';
+import { Route } from 'react-router-dom';
+import { createMemoryHistory, History } from 'history';
+import userEvent from '@testing-library/user-event';
+import { createDefaultStore, login, renderWrapped } from '../../../../../test/utils';
+import { initializeConfiguration } from '../../../../config/config';
+import {
+  amlChecksBackend,
+  applicationsBackend,
+  fundsBackend,
+  paymentLinkBackend,
+  pensionAccountStatementBackend,
+  returnsBackend,
+  userBackend,
+  userConversionBackend,
+} from '../../../../../test/backend';
+import LoggedInApp from '../../../../LoggedInApp';
+
+describe('When a user is setting up third pillar payments via employer', () => {
+  const server = setupServer();
+  let history: History;
+
+  const windowLocation = jest.fn();
+  Object.defineProperty(window, 'location', {
+    value: {
+      replace: windowLocation,
+    },
+  });
+
+  function initializeComponent() {
+    history = createMemoryHistory();
+    const store = createDefaultStore(history as any);
+    login(store);
+
+    renderWrapped(<Route path="" component={LoggedInApp} />, history as any, store);
+  }
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  beforeEach(async () => {
+    initializeConfiguration();
+
+    userConversionBackend(server);
+    userBackend(server);
+    amlChecksBackend(server);
+    pensionAccountStatementBackend(server);
+    fundsBackend(server);
+    paymentLinkBackend(server);
+    applicationsBackend(server);
+    returnsBackend(server);
+
+    initializeComponent();
+
+    history.push('/3rd-pillar-employer');
+  });
+
+  test('can switch between private and public employer', async () => {
+    expect(
+      await screen.findByText(
+        'Application to the employer to pay directly from the salary to III pillar',
+      ),
+    ).toBeInTheDocument();
+
+    const publicOption = await publicSectorOption();
+    const privateOption = await privateSectorOption();
+
+    act(() => {
+      userEvent.click(publicOption);
+    });
+    expect(await publicSectorOption()).toBeChecked();
+    expect(await navigateToRtkFormButton()).toBeVisible();
+
+    act(() => {
+      userEvent.click(privateOption);
+    });
+    expect(await privateSectorOption()).toBeChecked();
+    expect(await saveApplicationFormButton()).toBeVisible();
+  });
+
+  describe('private sector employer', () => {
+    test('private sector employer guide is shown by default', async () => {
+      expect(
+        await screen.findByText(
+          'Application to the employer to pay directly from the salary to III pillar',
+        ),
+      ).toBeInTheDocument();
+
+      expect(await privateSectorOption()).toBeChecked();
+      expect(await publicSectorOption()).not.toBeChecked();
+
+      expect(await saveApplicationFormButton()).toBeVisible();
+
+      expect(
+        await screen.findByText(
+          "Digitally sign the application and e-mail it to your employer's accountant.",
+        ),
+      );
+
+      expect(await screen.findByText('John Doe')).toBeVisible();
+      expect(await screen.findByText('9876543210')).toBeVisible();
+    });
+
+    test('private sector employer button navigates to form template', async () => {
+      expect(
+        await screen.findByText(
+          'Application to the employer to pay directly from the salary to III pillar',
+        ),
+      ).toBeInTheDocument();
+
+      const saveFormButton = await saveApplicationFormButton();
+
+      expect(saveFormButton).toBeVisible();
+      expect(saveFormButton).toHaveAttribute(
+        'href',
+        'https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit',
+      );
+    });
+  });
+
+  describe('public sector employer', () => {
+    test('can switch to public sector employer and navigate to government portal', async () => {
+      expect(
+        await screen.findByText(
+          'Application to the employer to pay directly from the salary to III pillar',
+        ),
+      ).toBeInTheDocument();
+
+      const publicOption = await publicSectorOption();
+
+      act(() => {
+        userEvent.click(publicOption);
+      });
+      expect(await publicSectorOption()).toBeChecked();
+
+      expect(await screen.findByText('Digitally sign the application in RTK.'));
+      const navigateToRtkButton = await navigateToRtkFormButton();
+
+      expect(navigateToRtkButton).toBeVisible();
+      expect(navigateToRtkButton).toHaveAttribute(
+        'href',
+        'https://www.riigitootaja.ee/rtip-client/login',
+      );
+    });
+  });
+
+  const privateSectorOption = async () => screen.findByLabelText("I'm a private sector employee");
+  const publicSectorOption = async () => screen.findByLabelText("I'm a public sector employee");
+
+  const saveApplicationFormButton = async () =>
+    screen.queryByRole('link', { name: 'Save the application form' });
+  const navigateToRtkFormButton = async () =>
+    screen.queryByRole('link', { name: 'Sign in to RTK self service' });
+});

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -10,7 +10,7 @@ import Radio from '../../../../common/radio';
 export const EmployerPaymentDetails = () => {
   const { data: user } = useMe();
 
-  const [employerType, setEmployerType] = useState<'private' | 'public' | null>();
+  const [employerType, setEmployerType] = useState<'private' | 'public'>('private');
 
   if (!user) {
     return <Shimmer height={500} />;
@@ -48,15 +48,60 @@ export const EmployerPaymentDetails = () => {
         </p>
       </Radio>
 
-      {employerType && (
-        <div className="pt-3">
-          {employerType === 'private' && <PrivateEmployerGuide user={user} />}
-          {employerType === 'public' && null}
-        </div>
-      )}
+      <div className="pt-3">
+        {employerType === 'private' && <PrivateEmployerGuide user={user} />}
+        {employerType === 'public' && <PublicEmployerGuide user={user} />}
+      </div>
     </div>
   );
 };
+
+const PublicEmployerGuide = ({ user }: { user: User }) => (
+  <>
+    <Step number={1}>
+      <a
+        className="btn btn-primary text-nowrap px-3"
+        href="https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <FormattedMessage id="thirdPillarPayment.EMPLOYER.signInToRtk" />
+      </a>
+    </Step>
+
+    <Step number={2}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.rtkNavigationGuide" />
+    </Step>
+
+    <Step number={3}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.rtkFormFields" />
+      <div className="mt-3 p-4 ml-n4 payment-details-table">
+        <table>
+          <tbody>
+            <TextRow>
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent" />
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent.description" />
+            </TextRow>
+            <TextRow>
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.pensionAccountNumber" />
+              {user.pensionAccountNumber}
+            </TextRow>
+            <TextRow>
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.fullName" />
+              {getFullName(user)}
+            </TextRow>
+          </tbody>
+        </table>
+      </div>
+    </Step>
+    <Step number={4}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.rtkDigitalSignature" />
+    </Step>
+    <Step number={5}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.salaryPayment" />
+    </Step>
+  </>
+);
 
 const PrivateEmployerGuide = ({ user }: { user: User }) => (
   <>

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { TextRow } from './row/TextRow';
 import { useMe } from '../../../../common/apiHooks';

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -10,7 +10,9 @@ import Radio from '../../../../common/radio';
 export const EmployerPaymentDetails = () => {
   const { data: user } = useMe();
 
-  const [employerType, setEmployerType] = useState<'private' | 'public'>('private');
+  const [employerType, setEmployerType] = useState<'PRIVATE_SECTOR' | 'PUBLIC_SECTOR'>(
+    'PRIVATE_SECTOR',
+  );
 
   if (!user) {
     return <Shimmer height={500} />;
@@ -25,9 +27,9 @@ export const EmployerPaymentDetails = () => {
         name="employer-type"
         id="employer-type-private"
         className="mt-4 p-3"
-        selected={employerType === 'private'}
+        selected={employerType === 'PRIVATE_SECTOR'}
         onSelect={() => {
-          setEmployerType('private');
+          setEmployerType('PRIVATE_SECTOR');
         }}
       >
         <p className="m-0">
@@ -38,9 +40,9 @@ export const EmployerPaymentDetails = () => {
         name="employer-type"
         id="employer-type-public"
         className="mt-3"
-        selected={employerType === 'public'}
+        selected={employerType === 'PUBLIC_SECTOR'}
         onSelect={() => {
-          setEmployerType('public');
+          setEmployerType('PUBLIC_SECTOR');
         }}
       >
         <p className="m-0">
@@ -49,8 +51,8 @@ export const EmployerPaymentDetails = () => {
       </Radio>
 
       <div className="p-4 mt-5 payment-details">
-        {employerType === 'private' && <PrivateEmployerGuide user={user} />}
-        {employerType === 'public' && <PublicEmployerGuide user={user} />}
+        {employerType === 'PRIVATE_SECTOR' && <PrivateEmployerGuide user={user} />}
+        {employerType === 'PUBLIC_SECTOR' && <PublicEmployerGuide user={user} />}
       </div>
     </>
   );

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -1,80 +1,80 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { connect } from 'react-redux';
 import { TextRow } from './row/TextRow';
-import { State } from '../../../../../types';
+import { useMe } from '../../../../common/apiHooks';
+import { Shimmer } from '../../../../common/shimmer/Shimmer';
+import { getFullName } from '../../../../common/utils';
 
-export const EmployerPaymentDetails: React.FunctionComponent<{
-  pensionAccountNumber: string;
-  fullName: string;
-}> = ({ pensionAccountNumber, fullName }) => (
-  <div className="mt-4 payment-details p-4">
-    <h3>
-      <FormattedMessage id="thirdPillarPayment.EMPLOYER.title" />
-    </h3>
-    <div className="d-sm-flex py-2">
-      <span className="flex-shrink-0 tv-step__number mr-3">
-        <b>1</b>
-      </span>
-      <span className="flex-grow-1 align-self-center">
-        <a
-          className="btn btn-primary text-nowrap px-3"
-          href="https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <FormattedMessage id="thirdPillarPayment.EMPLOYER.form" />
-        </a>
-      </span>
-    </div>
+export const EmployerPaymentDetails = () => {
+  const { data: user } = useMe();
 
-    <div className="d-sm-flex py-2">
-      <span className="flex-shrink-0 tv-step__number mr-3">
-        <b>2</b>
-      </span>
-      <span className="flex-grow-1 align-self-center">
-        <FormattedMessage id="thirdPillarPayment.EMPLOYER.formFields" />
-        <div className="mt-3 p-4 ml-n4 payment-details-table">
-          <table>
-            <tbody>
-              <TextRow>
-                <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent" />
-                <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent.description" />
-              </TextRow>
-              <TextRow>
-                <FormattedMessage id="thirdPillarPayment.EMPLOYER.pensionAccountNumber" />
-                {pensionAccountNumber}
-              </TextRow>
-              <TextRow>
-                <FormattedMessage id="thirdPillarPayment.EMPLOYER.fullName" />
-                {fullName}
-              </TextRow>
-            </tbody>
-          </table>
-        </div>
-      </span>
-    </div>
-    <div className="d-sm-flex py-2">
-      <span className="flex-shrink-0 tv-step__number mr-3">
-        <b>3</b>
-      </span>
-      <span className="flex-grow-1 align-self-center">
-        <FormattedMessage id="thirdPillarPayment.EMPLOYER.digitalSignature" />
-      </span>
-    </div>
-    <div className="d-sm-flex py-2">
-      <span className="flex-shrink-0 tv-step__number mr-3">
-        <b>4</b>
-      </span>
-      <span className="flex-grow-1 align-self-center">
-        <FormattedMessage id="thirdPillarPayment.EMPLOYER.salaryPayment" />
-      </span>
-    </div>
-  </div>
-);
+  if (!user) {
+    return <Shimmer height={500} />;
+  }
 
-const mapStateToProps = (state: State) => ({
-  pensionAccountNumber: state.login.user && state.login.user.pensionAccountNumber,
-  fullName: state.login.user && `${state.login.user.firstName} ${state.login.user.lastName}`,
-});
-export default connect(mapStateToProps)(EmployerPaymentDetails);
+  return (
+    <div className="mt-4 payment-details p-4">
+      <h3>
+        <FormattedMessage id="thirdPillarPayment.EMPLOYER.title" />
+      </h3>
+      <div className="d-sm-flex py-2">
+        <span className="flex-shrink-0 tv-step__number mr-3">
+          <b>1</b>
+        </span>
+        <span className="flex-grow-1 align-self-center">
+          <a
+            className="btn btn-primary text-nowrap px-3"
+            href="https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <FormattedMessage id="thirdPillarPayment.EMPLOYER.form" />
+          </a>
+        </span>
+      </div>
+
+      <div className="d-sm-flex py-2">
+        <span className="flex-shrink-0 tv-step__number mr-3">
+          <b>2</b>
+        </span>
+        <span className="flex-grow-1 align-self-center">
+          <FormattedMessage id="thirdPillarPayment.EMPLOYER.formFields" />
+          <div className="mt-3 p-4 ml-n4 payment-details-table">
+            <table>
+              <tbody>
+                <TextRow>
+                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent" />
+                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent.description" />
+                </TextRow>
+                <TextRow>
+                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.pensionAccountNumber" />
+                  {user.pensionAccountNumber}
+                </TextRow>
+                <TextRow>
+                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.fullName" />
+                  {getFullName(user)}
+                </TextRow>
+              </tbody>
+            </table>
+          </div>
+        </span>
+      </div>
+      <div className="d-sm-flex py-2">
+        <span className="flex-shrink-0 tv-step__number mr-3">
+          <b>3</b>
+        </span>
+        <span className="flex-grow-1 align-self-center">
+          <FormattedMessage id="thirdPillarPayment.EMPLOYER.digitalSignature" />
+        </span>
+      </div>
+      <div className="d-sm-flex py-2">
+        <span className="flex-shrink-0 tv-step__number mr-3">
+          <b>4</b>
+        </span>
+        <span className="flex-grow-1 align-self-center">
+          <FormattedMessage id="thirdPillarPayment.EMPLOYER.salaryPayment" />
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { TextRow } from './row/TextRow';
 import { useMe } from '../../../../common/apiHooks';
 import { Shimmer } from '../../../../common/shimmer/Shimmer';
 import { getFullName } from '../../../../common/utils';
+import { User } from '../../../../common/apiModels';
+import Radio from '../../../../common/radio';
 
 export const EmployerPaymentDetails = () => {
   const { data: user } = useMe();
+
+  const [employerType, setEmployerType] = useState<'private' | 'public' | null>();
 
   if (!user) {
     return <Shimmer height={500} />;
@@ -17,64 +21,91 @@ export const EmployerPaymentDetails = () => {
       <h3>
         <FormattedMessage id="thirdPillarPayment.EMPLOYER.title" />
       </h3>
-      <div className="d-sm-flex py-2">
-        <span className="flex-shrink-0 tv-step__number mr-3">
-          <b>1</b>
-        </span>
-        <span className="flex-grow-1 align-self-center">
-          <a
-            className="btn btn-primary text-nowrap px-3"
-            href="https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <FormattedMessage id="thirdPillarPayment.EMPLOYER.form" />
-          </a>
-        </span>
-      </div>
+      <Radio
+        name="payment-type"
+        id="payment-type-single"
+        className="mt-3 p-3"
+        selected={employerType === 'private'}
+        onSelect={() => {
+          setEmployerType('private');
+        }}
+      >
+        <p className="m-0">
+          <FormattedMessage id="thirdPillarPayment.EMPLOYER.privateEmployer" />
+        </p>
+      </Radio>
+      <Radio
+        name="payment-type"
+        id="payment-type-recurring"
+        className="mt-3"
+        selected={employerType === 'public'}
+        onSelect={() => {
+          setEmployerType('public');
+        }}
+      >
+        <p className="m-0">
+          <FormattedMessage id="thirdPillarPayment.EMPLOYER.publicEmployer" />
+        </p>
+      </Radio>
 
-      <div className="d-sm-flex py-2">
-        <span className="flex-shrink-0 tv-step__number mr-3">
-          <b>2</b>
-        </span>
-        <span className="flex-grow-1 align-self-center">
-          <FormattedMessage id="thirdPillarPayment.EMPLOYER.formFields" />
-          <div className="mt-3 p-4 ml-n4 payment-details-table">
-            <table>
-              <tbody>
-                <TextRow>
-                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent" />
-                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent.description" />
-                </TextRow>
-                <TextRow>
-                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.pensionAccountNumber" />
-                  {user.pensionAccountNumber}
-                </TextRow>
-                <TextRow>
-                  <FormattedMessage id="thirdPillarPayment.EMPLOYER.fullName" />
-                  {getFullName(user)}
-                </TextRow>
-              </tbody>
-            </table>
-          </div>
-        </span>
-      </div>
-      <div className="d-sm-flex py-2">
-        <span className="flex-shrink-0 tv-step__number mr-3">
-          <b>3</b>
-        </span>
-        <span className="flex-grow-1 align-self-center">
-          <FormattedMessage id="thirdPillarPayment.EMPLOYER.digitalSignature" />
-        </span>
-      </div>
-      <div className="d-sm-flex py-2">
-        <span className="flex-shrink-0 tv-step__number mr-3">
-          <b>4</b>
-        </span>
-        <span className="flex-grow-1 align-self-center">
-          <FormattedMessage id="thirdPillarPayment.EMPLOYER.salaryPayment" />
-        </span>
-      </div>
+      {employerType && (
+        <div className="pt-3">
+          {employerType === 'private' && <PrivateEmployerGuide user={user} />}
+          {employerType === 'public' && null}
+        </div>
+      )}
     </div>
   );
 };
+
+const PrivateEmployerGuide = ({ user }: { user: User }) => (
+  <>
+    <Step number={1}>
+      <a
+        className="btn btn-primary text-nowrap px-3"
+        href="https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <FormattedMessage id="thirdPillarPayment.EMPLOYER.form" />
+      </a>
+    </Step>
+
+    <Step number={2}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.formFields" />
+      <div className="mt-3 p-4 ml-n4 payment-details-table">
+        <table>
+          <tbody>
+            <TextRow>
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent" />
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent.description" />
+            </TextRow>
+            <TextRow>
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.pensionAccountNumber" />
+              {user.pensionAccountNumber}
+            </TextRow>
+            <TextRow>
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.fullName" />
+              {getFullName(user)}
+            </TextRow>
+          </tbody>
+        </table>
+      </div>
+    </Step>
+    <Step number={3}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.digitalSignature" />
+    </Step>
+    <Step number={4}>
+      <FormattedMessage id="thirdPillarPayment.EMPLOYER.salaryPayment" />
+    </Step>
+  </>
+);
+
+const Step = ({ number, children }: PropsWithChildren<{ number: number }>) => (
+  <div className="d-sm-flex py-2">
+    <span className="flex-shrink-0 tv-step__number mr-3">
+      <b>{number}</b>
+    </span>
+    <span className="flex-grow-1 align-self-center">{children}</span>
+  </div>
+);

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -17,14 +17,14 @@ export const EmployerPaymentDetails = () => {
   }
 
   return (
-    <div className="mt-4 payment-details p-4">
-      <h3>
+    <>
+      <h2 className="mt-3">
         <FormattedMessage id="thirdPillarPayment.EMPLOYER.title" />
-      </h3>
+      </h2>
       <Radio
         name="employer-type"
         id="employer-type-private"
-        className="mt-3 p-3"
+        className="mt-4 p-3"
         selected={employerType === 'private'}
         onSelect={() => {
           setEmployerType('private');
@@ -48,11 +48,11 @@ export const EmployerPaymentDetails = () => {
         </p>
       </Radio>
 
-      <div className="pt-3">
+      <div className="p-4 mt-5 payment-details">
         {employerType === 'private' && <PrivateEmployerGuide user={user} />}
         {employerType === 'public' && <PublicEmployerGuide user={user} />}
       </div>
-    </div>
+    </>
   );
 };
 
@@ -103,7 +103,7 @@ const PublicEmployerGuide = ({ user }: { user: User }) => (
   </>
 );
 
-const PrivateEmployerGuide = ({ user }: { user: User }) => (
+export const PrivateEmployerGuide = ({ user }: { user: User }) => (
   <>
     <Step number={1}>
       <a

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -22,8 +22,8 @@ export const EmployerPaymentDetails = () => {
         <FormattedMessage id="thirdPillarPayment.EMPLOYER.title" />
       </h3>
       <Radio
-        name="payment-type"
-        id="payment-type-single"
+        name="employer-type"
+        id="employer-type-private"
         className="mt-3 p-3"
         selected={employerType === 'private'}
         onSelect={() => {
@@ -35,8 +35,8 @@ export const EmployerPaymentDetails = () => {
         </p>
       </Radio>
       <Radio
-        name="payment-type"
-        id="payment-type-recurring"
+        name="employer-type"
+        id="employer-type-public"
         className="mt-3"
         selected={employerType === 'public'}
         onSelect={() => {

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/EmployerPaymentDetails.tsx
@@ -61,7 +61,7 @@ const PublicEmployerGuide = ({ user }: { user: User }) => (
     <Step number={1}>
       <a
         className="btn btn-primary text-nowrap px-3"
-        href="https://docs.google.com/document/d/1ZnF9CBxnXWzCjDz-wk1H84pz_yD3EIcD3WPBYt5RuDA/edit"
+        href="https://www.riigitootaja.ee/rtip-client/login"
         target="_blank"
         rel="noreferrer"
       >
@@ -79,8 +79,8 @@ const PublicEmployerGuide = ({ user }: { user: User }) => (
         <table>
           <tbody>
             <TextRow>
-              <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent" />
-              <FormattedMessage id="thirdPillarPayment.EMPLOYER.percent.description" />
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.rtkAmount" />
+              <FormattedMessage id="thirdPillarPayment.EMPLOYER.rtkAmount.description" />
             </TextRow>
             <TextRow>
               <FormattedMessage id="thirdPillarPayment.EMPLOYER.pensionAccountNumber" />

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -477,6 +477,8 @@
   "thirdPillarPayment.pensionAccountNumber": "Your pension account number",
 
   "thirdPillarPayment.EMPLOYER.title": "Application to the employer to pay directly from the salary to III pillar",
+  "thirdPillarPayment.EMPLOYER.publicEmployer": "I'm a public sector employee",
+  "thirdPillarPayment.EMPLOYER.privateEmployer": "I'm a private sector employee",
   "thirdPillarPayment.EMPLOYER.form": "Save the application form",
   "thirdPillarPayment.EMPLOYER.formFields": "Fill in the fields:",
   "thirdPillarPayment.EMPLOYER.percent": "Percentage of gross salary",
@@ -485,6 +487,12 @@
   "thirdPillarPayment.EMPLOYER.fullName": "First and last name",
   "thirdPillarPayment.EMPLOYER.digitalSignature": "Digitally sign the application and e-mail it to your employer's accountant.",
   "thirdPillarPayment.EMPLOYER.salaryPayment": "Every payday, an automatic contribution is made to your III pillar.",
+  "thirdPillarPayment.EMPLOYER.signInToRtk": "Sign in to RTK self service",
+  "thirdPillarPayment.EMPLOYER.rtkAmount": "Sum in euros",
+  "thirdPillarPayment.EMPLOYER.rtkAmount.description": "Monthly sum to transfer to III pillar",
+  "thirdPillarPayment.EMPLOYER.rtkNavigationGuide": "Navigate: Isikuandmed → Esita avaldus → III samba sissemaksed otse palgast",
+  "thirdPillarPayment.EMPLOYER.rtkFormFields": "Necessary information for the application:",
+  "thirdPillarPayment.EMPLOYER.rtkDigitalSignature": "Digitally sign the application in RTK.",
 
   "thirdPillarSuccess.done": "Payment done",
   "thirdPillarSuccess.message": "Payment will reach the fund within 2 working days.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -476,6 +476,8 @@
   "thirdPillarPayment.pensionAccountNumber": "Sinu personaalne pensionikonto number",
 
   "thirdPillarPayment.EMPLOYER.title": "Avaldus tööandjale otse palgast III sambasse maksmiseks",
+  "thirdPillarPayment.EMPLOYER.publicEmployer": "Olen avaliku sektori töötaja",
+  "thirdPillarPayment.EMPLOYER.privateEmployer": "Olen erasektori töötaja",
   "thirdPillarPayment.EMPLOYER.form": "Salvesta avalduse blankett",
   "thirdPillarPayment.EMPLOYER.formFields": "Täida avalduse väljad:",
   "thirdPillarPayment.EMPLOYER.percent": "Protsent brutopalgast",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -486,6 +486,10 @@
   "thirdPillarPayment.EMPLOYER.fullName": "Ees- ja perekonnanimi",
   "thirdPillarPayment.EMPLOYER.digitalSignature": "Digiallkirjasta avaldus ja saada e-kirjaga oma tööandja raamatupidajale.",
   "thirdPillarPayment.EMPLOYER.salaryPayment": "Iga palgapäev tehakse automaatne sissemakse sinu III sambasse.",
+  "thirdPillarPayment.EMPLOYER.signInToRtk": "Sisene RTK iseteenindusse",
+  "thirdPillarPayment.EMPLOYER.rtkNavigationGuide": "Mine: Isikuandmed → Esita avaldus → III samba sissemaksed otse palgast",
+  "thirdPillarPayment.EMPLOYER.rtkFormFields": "Vajalik info avalduse täitmiseks:",
+  "thirdPillarPayment.EMPLOYER.rtkDigitalSignature": "Kinnita avaldus RTK portaalis digiallkirjaga.",
 
   "thirdPillarSuccess.done": "Sissemakse tehtud",
   "thirdPillarSuccess.message": "Makse jõuab fondi 2 tööpäeva jooksul.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -487,6 +487,8 @@
   "thirdPillarPayment.EMPLOYER.digitalSignature": "Digiallkirjasta avaldus ja saada e-kirjaga oma tööandja raamatupidajale.",
   "thirdPillarPayment.EMPLOYER.salaryPayment": "Iga palgapäev tehakse automaatne sissemakse sinu III sambasse.",
   "thirdPillarPayment.EMPLOYER.signInToRtk": "Sisene RTK iseteenindusse",
+  "thirdPillarPayment.EMPLOYER.rtkAmount": "Summa eurodes",
+  "thirdPillarPayment.EMPLOYER.rtkAmount.description": "Igakuine summa, mida soovid III sambasse suunata",
   "thirdPillarPayment.EMPLOYER.rtkNavigationGuide": "Mine: Isikuandmed → Esita avaldus → III samba sissemaksed otse palgast",
   "thirdPillarPayment.EMPLOYER.rtkFormFields": "Vajalik info avalduse täitmiseks:",
   "thirdPillarPayment.EMPLOYER.rtkDigitalSignature": "Kinnita avaldus RTK portaalis digiallkirjaga.",


### PR DESCRIPTION
Adds onboarding guide for direct employer 3rd pillar payments for public sector employees via Riigitöötaja Iseteenindusportaal.

Adds radio button to switch between private and public sector employees, with private selected by default. 

Covers the view with tests.

![localhost_3000_3rd-pillar-employer_language=et](https://github.com/TulevaEE/onboarding-client/assets/3755903/cc35cb44-e231-401b-bdf2-b70529785065)


Minor changes:
* Turns off required return type rule to rely more on inferred types.
* Converts utils to typescript. 
* Adds util for full name getter.

