### PR TITLE
Improve translation key type definition (has to be present both in EN and ET)

### DIFF
--- a/src/components/account/ApplicationSection/ApplicationCards.tsx
+++ b/src/components/account/ApplicationSection/ApplicationCards.tsx
@@ -20,6 +20,7 @@ import Euro from '../../common/Euro';
 import { Fees } from '../../common/Percentage/Fees';
 import { formatMonth } from '../../common/dateFormatter';
 import { isBeforeCancellationDeadline } from './ApplicationFunctions';
+import { TranslationKey } from '../../translations';
 
 export const ApplicationCard: React.FunctionComponent<{
   application: Application;
@@ -154,7 +155,7 @@ const TransferApplicationCard: React.FunctionComponent<{
           },
           application.details.exchanges.map(({ targetFund, targetPik, amount }) => [
             {
-              key: 'applications.type.transfer.targetFund',
+              key: 'applications.type.transfer.targetFund' as const,
               value: targetFund?.name ? (
                 <>
                   {targetFund.name} <br />
@@ -168,7 +169,7 @@ const TransferApplicationCard: React.FunctionComponent<{
               ),
             },
             {
-              key: 'applications.type.transfer.amount',
+              key: 'applications.type.transfer.amount' as const,
               value: isThirdPillarTransfer ? (
                 amount
               ) : (
@@ -277,7 +278,7 @@ const ResumeContributionsCard: React.FunctionComponent<{
 );
 
 const BaseApplicationCard: React.FunctionComponent<{
-  titleKey: string;
+  titleKey: TranslationKey;
   application: Application;
   children: React.ReactNode;
   allowedActions: ApplicationAction[];

--- a/src/components/account/ApplicationSection/DefinitionList.tsx
+++ b/src/components/account/ApplicationSection/DefinitionList.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 import styles from './DefinitionList.module.scss';
+import { TranslationKey } from '../../translations';
 
 export interface Definition {
-  key: string;
+  key: TranslationKey;
   value: React.ReactNode;
   alignRight?: boolean;
 }

--- a/src/components/account/ComparisonCalculator/ComparisonCalculator.tsx
+++ b/src/components/account/ComparisonCalculator/ComparisonCalculator.tsx
@@ -25,6 +25,7 @@ import {
   RootState,
 } from './types';
 import { getCurrentPath, getFullYearsSince, sortFundsWithTulevaFirst } from './utility';
+import { TranslationKey } from '../../translations';
 
 const formatMessageWithTags = ({ id, values }: FormatTagsMessageDescriptor) => (
   <FormattedMessage
@@ -446,7 +447,7 @@ const ComparisonCalculator: React.FC = () => {
         </div>
         <div className="bar-label position-absolute" style={barLabelStyle}>
           {properties.label.includes('.') ? (
-            <FormattedMessage id={properties.label} />
+            <FormattedMessage id={properties.label as TranslationKey} />
           ) : (
             properties.label
           )}

--- a/src/components/account/ComparisonCalculator/select/Select.tsx
+++ b/src/components/account/ComparisonCalculator/select/Select.tsx
@@ -44,8 +44,8 @@ export const Select: FC<SelectProps> = ({
   const { formatMessage } = useIntl();
 
   const getLabel = (option: Option | OptionGroup) => {
-    if (translate && option.translate) {
-      return formatMessage({ id: option.label });
+    if (translate && option.translate !== false) {
+      return formatMessage({ id: option.label as TranslationKey });
     }
 
     return option.label;

--- a/src/components/account/ComparisonCalculator/select/Select.tsx
+++ b/src/components/account/ComparisonCalculator/select/Select.tsx
@@ -1,19 +1,28 @@
 import React, { FC } from 'react';
 import { useIntl } from 'react-intl';
+import { TranslationKey } from '../../../translations';
 
-export interface Option {
+export type Option = BaseOption & TranslateOption;
+
+type BaseOption = {
   value: string;
-  label: string;
   disabled?: boolean;
   divider?: boolean;
-  translate?: boolean;
-}
+};
 
-export interface OptionGroup {
-  label: string;
+type TranslateOption =
+  | {
+      translate?: false;
+      label: string;
+    }
+  | {
+      translate: true;
+      label: TranslationKey;
+    };
+
+export type OptionGroup = {
   options: Option[];
-  translate?: boolean;
-}
+} & TranslateOption;
 
 interface SelectProps {
   options: (Option | OptionGroup)[];
@@ -35,9 +44,11 @@ export const Select: FC<SelectProps> = ({
   const { formatMessage } = useIntl();
 
   const getLabel = (option: Option | OptionGroup) => {
-    return translate && option.translate !== false
-      ? formatMessage({ id: option.label })
-      : option.label;
+    if (translate && option.translate) {
+      return formatMessage({ id: option.label });
+    }
+
+    return option.label;
   };
 
   const renderOption = (option: Option) => {

--- a/src/components/account/ComparisonCalculator/types.ts
+++ b/src/components/account/ComparisonCalculator/types.ts
@@ -1,5 +1,6 @@
 import { MessageDescriptor } from 'react-intl';
 import { Fund, UserConversion } from '../../common/apiModels';
+import { TranslationKey } from '../../translations';
 
 export interface GraphBarProperties {
   color: string;
@@ -69,6 +70,6 @@ export interface FormatValues {
 }
 
 export interface FormatTagsMessageDescriptor extends MessageDescriptor {
-  id: string;
+  id: TranslationKey;
   values?: FormatValues;
 }

--- a/src/components/account/statusBox/statusBoxRow/StatusBoxRow.test.tsx
+++ b/src/components/account/statusBox/statusBoxRow/StatusBoxRow.test.tsx
@@ -11,13 +11,13 @@ describe('Status Box Row', () => {
   });
 
   it('renders the name', () => {
-    const displayName = <FormattedMessage id="i am a name" />;
+    const displayName = <span>i am a name</span>;
     component.setProps({ name: displayName });
     expect(component.contains(displayName)).toBe(true);
   });
 
   it('renders action button if row status not ok', () => {
-    const action = <FormattedMessage id="do next" />;
+    const action = <span>do next</span>;
     component.setProps({ showAction: true, children: action });
     expect(component.contains(action)).toBe(true);
   });

--- a/src/components/flows/secondPillar/selectSources/SelectSources.tsx
+++ b/src/components/flows/secondPillar/selectSources/SelectSources.tsx
@@ -16,6 +16,7 @@ import { ErrorResponse, Fund, SourceFund } from '../../../common/apiModels';
 import { SourceSelection } from '../../../exchange/types';
 import { State } from '../../../../types';
 import { isContributionsFundAlreadyActive } from '../../../exchange/reducer';
+import { TranslationKey } from '../../../translations';
 
 function selectAllWithTarget(
   sourceFunds: SourceFund[] | null,
@@ -32,7 +33,7 @@ function selectAllWithTarget(
   );
 }
 
-function validate(selections: SourceSelection[] | null): string | null {
+function validate(selections: SourceSelection[] | null): TranslationKey | null {
   const sourceFundPercentages: { [key: string]: number } = {};
   let errorDescriptionCode = null;
   selections?.forEach((selection) => {
@@ -128,7 +129,7 @@ export const SelectSources = ({
   const tulevaTargetFunds = targetFunds?.filter((fund) => isTuleva(fund));
   const defaultTargetFund = tulevaTargetFunds[0];
 
-  function validationSelectionErrorElement(errorCode: string | null): ReactNode {
+  function validationSelectionErrorElement(errorCode: TranslationKey | null): ReactNode {
     if (!errorCode) {
       return null;
     }

--- a/src/components/flows/secondPillar/selectSources/targetFundSelector/TargetFundSelector.tsx
+++ b/src/components/flows/secondPillar/selectSources/targetFundSelector/TargetFundSelector.tsx
@@ -12,6 +12,8 @@ type Props = {
   isSelected: (fund: Fund) => boolean;
 };
 
+type TulevaFundIsin = 'EE3600109435' | 'EE3600109443' | 'EE3600001707';
+
 export const TargetFundSelector: React.FunctionComponent<Props> = ({
   targetFunds = [],
   onSelectFund,
@@ -50,11 +52,15 @@ export const TargetFundSelector: React.FunctionComponent<Props> = ({
                   <Fees className="text-bold" value={fund.ongoingChargesFigure} />
                 </div>
                 <div className="mb-2">
-                  <FormattedMessage id={`target.funds.${fund.isin}.description`} />
+                  <FormattedMessage
+                    id={`target.funds.${fund.isin as TulevaFundIsin}.description`}
+                  />
                 </div>
                 <a
                   className="tv-target-fund__terms-link"
-                  href={formatMessage({ id: `target.funds.${fund.isin}.terms.link` })}
+                  href={formatMessage({
+                    id: `target.funds.${fund.isin as TulevaFundIsin}.terms.link`,
+                  })}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/OtherBankPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/OtherBankPaymentDetails.tsx
@@ -9,7 +9,10 @@ import { PaymentType } from '../../../../common/apiModels';
 export const OtherBankPaymentDetails: React.FunctionComponent<{
   amount: string;
   personalCode: string;
-  paymentType: PaymentType;
+  paymentType: Exclude<
+    PaymentType,
+    PaymentType.EMPLOYER | PaymentType.GIFT | PaymentType.MEMBER_FEE
+  >;
 }> = ({ amount, personalCode, paymentType }) => (
   <div className="mt-4 payment-details p-4">
     <h3>

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/OtherBankPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/OtherBankPaymentDetails.tsx
@@ -9,10 +9,7 @@ import { PaymentType } from '../../../../common/apiModels';
 export const OtherBankPaymentDetails: React.FunctionComponent<{
   amount: string;
   personalCode: string;
-  paymentType: Exclude<
-    PaymentType,
-    PaymentType.EMPLOYER | PaymentType.GIFT | PaymentType.MEMBER_FEE
-  >;
+  paymentType: PaymentType.SINGLE | PaymentType.RECURRING;
 }> = ({ amount, personalCode, paymentType }) => (
   <div className="mt-4 payment-details p-4">
     <h3>

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/row/AccountNumberRow.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/paymentDetails/row/AccountNumberRow.tsx
@@ -9,8 +9,10 @@ const accountNumber: { [bank: string]: string } = {
   luminor: 'EE961700017004379157',
 };
 
+type Bank = 'swedbank' | 'seb' | 'lhv' | 'luminor';
+
 export const AccountNumberRow: React.FunctionComponent<{
-  bank: string;
+  bank: Bank;
   children: React.ReactNode;
 }> = ({ bank, children }) => (
   <tr>

--- a/src/components/translations/index.ts
+++ b/src/components/translations/index.ts
@@ -3,4 +3,4 @@ import en from './translations.en.json';
 
 export default { et, en };
 
-export type TranslationKey = keyof (typeof et & typeof en);
+export type TranslationKey = keyof typeof et & keyof typeof en;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,9 @@
+import { TranslationKey } from './components/translations';
+
+declare global {
+  namespace FormatjsIntl {
+    interface Message {
+      ids: TranslationKey;
+    }
+  }
+}


### PR DESCRIPTION
Improves translation key definition:
* Key has to be present in translation files.
* Key has to exist both in english and estonian.

Otherwise, typecheck fails. 

Uses [globals type definition override](https://stackoverflow.com/a/71963066) which isn't ideal, but was low effort.
