### PR TITLE
3rd pillar payment error handling & refactor

### DIFF
--- a/src/components/common/api.ts
+++ b/src/components/common/api.ts
@@ -286,8 +286,7 @@ export function createApplicationCancellation(applicationId: number): Promise<Ca
   return postWithAuthentication(getEndpoint(`/v1/applications/${applicationId}/cancellations`), {});
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export function createTrackedEvent(type: string, data: Record<string, unknown>): Promise<any> {
+export function createTrackedEvent(type: string, data: Record<string, unknown>): Promise<unknown> {
   return postWithAuthentication(getEndpoint('/v1/t'), { type, data });
 }
 
@@ -295,11 +294,10 @@ export function getPaymentLink(payment: Payment): Promise<PaymentLink> {
   return getWithAuthentication(getEndpoint('/v1/payments/link'), payment);
 }
 
-export function redirectToPayment(payment: Payment): void {
+export async function redirectToPayment(payment: Payment): Promise<void> {
   const wndw = getWindow(payment.type);
-  getPaymentLink(payment).then((paymentLink) => {
-    wndw.location.replace(paymentLink.url);
-  });
+  const paymentLink = await getPaymentLink(payment);
+  wndw.location.replace(paymentLink.url);
 }
 
 function getWindow(paymentType: PaymentType): Window {

--- a/src/components/common/http.ts
+++ b/src/components/common/http.ts
@@ -48,7 +48,8 @@ export async function getWithAuthentication(
   axiosConfig = {},
 ): Promise<any> {
   const axiosInstance = createAxiosInstance();
-  return axiosInstance.get(url, { params, ...axiosConfig }).then((response) => response.data);
+  const response = await axiosInstance.get(url, { params, ...axiosConfig });
+  return response.data;
 }
 
 export async function postWithAuthentication(

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/BankButton.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/BankButton.tsx
@@ -1,29 +1,44 @@
 import React from 'react';
+import { useIntl } from 'react-intl';
+import { BankKey, bankKeyToBankNameMap } from './types';
 
-export const BankButton: React.FunctionComponent<{
-  bankKey: string;
-  bankName: string;
-  paymentBank: string;
-  setPaymentBank: (paymentBank: string) => void;
+type Props = {
+  bankKey: BankKey | 'other';
+  paymentBank: BankKey | 'other' | null;
+  setPaymentBank: (paymentBank: BankKey | 'other') => void;
   disabled?: boolean;
-}> = ({ bankKey, bankName, paymentBank, setPaymentBank, disabled = false }) => (
-  <div className="btn-group-toggle d-inline-block mt-2 mr-2">
-    <label
-      className={`btn btn-light btn-payment btn-${bankKey} text-nowrap ${
-        paymentBank === bankKey ? 'active' : ''
-      }`}
-    >
-      <input
-        type="radio"
-        name="banks"
-        id={bankKey}
-        checked={paymentBank === bankKey}
-        onChange={() => {
-          setPaymentBank(bankKey);
-        }}
-        disabled={disabled}
-      />
-      {bankName}
-    </label>
-  </div>
-);
+};
+
+export const BankButton = ({ bankKey, paymentBank, setPaymentBank, disabled = false }: Props) => {
+  const { formatMessage } = useIntl();
+
+  const getBankName = (key: Props['bankKey']) => {
+    if (key === 'other') {
+      return formatMessage({ id: 'thirdPillarPayment.otherBank' });
+    }
+
+    return bankKeyToBankNameMap[key];
+  };
+
+  return (
+    <div className="btn-group-toggle d-inline-block mt-2 mr-2">
+      <label
+        className={`btn btn-light btn-payment btn-${bankKey} text-nowrap ${
+          paymentBank === bankKey ? 'active' : ''
+        }`}
+      >
+        <input
+          type="radio"
+          name="banks"
+          id={bankKey}
+          checked={paymentBank === bankKey}
+          onChange={() => {
+            setPaymentBank(bankKey);
+          }}
+          disabled={disabled}
+        />
+        {getBankName(bankKey)}
+      </label>
+    </div>
+  );
+};

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
@@ -43,159 +43,157 @@ export const Payment: React.FunctionComponent = () => {
         <FormattedMessage id="thirdPillarPayment.title" />
       </h2>
       <PaymentTypeSelection paymentType={paymentType} setPaymentType={setPaymentType} />
-      {(paymentType === PaymentType.SINGLE || paymentType === PaymentType.RECURRING) && (
-        <>
-          <PaymentAmountInput
-            paymentType={paymentType}
-            value={paymentAmount}
-            onChange={(event) => {
-              const { value } = event.target;
-              const euroRegex = /^\d+([.,]\d{0,2})?$/;
+      <>
+        <PaymentAmountInput
+          paymentType={paymentType}
+          value={paymentAmount}
+          onChange={(event) => {
+            const { value } = event.target;
+            const euroRegex = /^\d+([.,]\d{0,2})?$/;
 
-              if (value === '' || euroRegex.test(value)) {
-                setPaymentAmount(value);
-              }
-            }}
-            onWheel={(event) => event.currentTarget.blur()}
-            className="mt-5"
-          />
+            if (value === '' || euroRegex.test(value)) {
+              setPaymentAmount(value);
+            }
+          }}
+          onWheel={(event) => event.currentTarget.blur()}
+          className="mt-5"
+        />
 
-          <div className="payment-amount-input-footer">
-            <ThirdPillarPaymentsAmount />
-            <div>
-              <small className="text-muted">
-                <a href="//tuleva.ee/iii-sammas/" target="_blank" rel="noreferrer">
-                  {paymentType === PaymentType.SINGLE && (
-                    <FormattedMessage id="thirdPillarPayment.singlePaymentHowMuch" />
-                  )}
-                  {paymentType === PaymentType.RECURRING && (
-                    <FormattedMessage id="thirdPillarPayment.recurringPaymentHowMuch" />
-                  )}
-                </a>
-              </small>
+        <div className="payment-amount-input-footer">
+          <ThirdPillarPaymentsAmount />
+          <div>
+            <small className="text-muted">
+              <a href="//tuleva.ee/iii-sammas/" target="_blank" rel="noreferrer">
+                {paymentType === PaymentType.SINGLE && (
+                  <FormattedMessage id="thirdPillarPayment.singlePaymentHowMuch" />
+                )}
+                {paymentType === PaymentType.RECURRING && (
+                  <FormattedMessage id="thirdPillarPayment.recurringPaymentHowMuch" />
+                )}
+              </a>
+            </small>
+          </div>
+        </div>
+
+        <div className="mt-5 payment-bank-title">
+          <b>
+            {paymentType === PaymentType.SINGLE && (
+              <FormattedMessage id="thirdPillarPayment.singlePaymentBank" />
+            )}
+            {paymentType === PaymentType.RECURRING && (
+              <FormattedMessage id="thirdPillarPayment.recurringPaymentBank" />
+            )}
+          </b>
+        </div>
+
+        <PaymentBankButtons paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+
+        <div className="payment-details-container">
+          {paymentType === PaymentType.RECURRING && paymentBank && (
+            <>
+              {paymentBank === 'swedbank' && (
+                <SwedbankRecurringPaymentDetails amount={paymentAmount} />
+              )}
+
+              {paymentBank === 'seb' && <SebRecurringPaymentDetails />}
+
+              {paymentBank === 'lhv' && <LhvRecurringPaymentDetails />}
+
+              {paymentBank === 'luminor' && (
+                <LuminorRecurringPaymentDetails
+                  amount={paymentAmount}
+                  personalCode={user.personalCode}
+                />
+              )}
+
+              {paymentBank === 'coop' && <CoopRecurringPaymentDetails />}
+
+              {paymentBank === 'other' && (
+                <OtherBankPaymentDetails
+                  personalCode={user.personalCode}
+                  amount={paymentAmount}
+                  paymentType={PaymentType.RECURRING}
+                />
+              )}
+            </>
+          )}
+          {paymentType === PaymentType.SINGLE && paymentBank === 'other' && (
+            <OtherBankPaymentDetails
+              personalCode={user.personalCode}
+              amount={paymentAmount}
+              paymentType={PaymentType.SINGLE}
+            />
+          )}
+          {paymentBank === 'other' && (
+            <div className="mt-4">
+              <Link to="/account">
+                <button type="button" className="btn btn-light">
+                  <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
+                </button>
+              </Link>
             </div>
-          </div>
-
-          <div className="mt-5 payment-bank-title">
-            <b>
-              {paymentType === PaymentType.SINGLE && (
-                <FormattedMessage id="thirdPillarPayment.singlePaymentBank" />
-              )}
-              {paymentType === PaymentType.RECURRING && (
-                <FormattedMessage id="thirdPillarPayment.recurringPaymentBank" />
-              )}
-            </b>
-          </div>
-
-          <PaymentBankButtons paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
-
-          <div className="payment-details-container">
-            {paymentType === PaymentType.RECURRING && paymentBank && (
-              <>
-                {paymentBank === 'swedbank' && (
-                  <SwedbankRecurringPaymentDetails amount={paymentAmount} />
-                )}
-
-                {paymentBank === 'seb' && <SebRecurringPaymentDetails />}
-
-                {paymentBank === 'lhv' && <LhvRecurringPaymentDetails />}
-
-                {paymentBank === 'luminor' && (
-                  <LuminorRecurringPaymentDetails
-                    amount={paymentAmount}
-                    personalCode={user.personalCode}
-                  />
-                )}
-
-                {paymentBank === 'coop' && <CoopRecurringPaymentDetails />}
-
-                {paymentBank === 'other' && (
-                  <OtherBankPaymentDetails
-                    personalCode={user.personalCode}
-                    amount={paymentAmount}
-                    paymentType={PaymentType.RECURRING}
-                  />
-                )}
-              </>
-            )}
-            {paymentType === PaymentType.SINGLE && paymentBank === 'other' && (
-              <OtherBankPaymentDetails
-                personalCode={user.personalCode}
-                amount={paymentAmount}
-                paymentType={PaymentType.SINGLE}
-              />
-            )}
-            {paymentBank === 'other' && (
-              <div className="mt-4">
-                <Link to="/account">
-                  <button type="button" className="btn btn-light">
-                    <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
+          )}
+          {paymentBank !== 'other' && (
+            <>
+              <div className="d-flex flex-wrap align-items-start">
+                <div className="mr-auto">
+                  <button
+                    type="button"
+                    className="btn btn-primary payment-button text-nowrap mt-4"
+                    disabled={isSubmitDisabled()}
+                    onClick={() => {
+                      redirectToPayment({
+                        recipientPersonalCode: user.personalCode,
+                        amount: Number(paymentAmount.replace(',', '.')),
+                        currency: 'EUR',
+                        type: paymentType,
+                        paymentChannel: paymentBank.toUpperCase() as PaymentChannel,
+                      });
+                    }}
+                  >
+                    {paymentType === PaymentType.SINGLE && (
+                      <FormattedMessage id="thirdPillarPayment.makePayment" />
+                    )}
+                    {paymentType === PaymentType.RECURRING && (
+                      <FormattedMessage id="thirdPillarPayment.setupRecurringPayment" />
+                    )}
                   </button>
-                </Link>
-              </div>
-            )}
-            {paymentBank !== 'other' && (
-              <>
-                <div className="d-flex flex-wrap align-items-start">
-                  <div className="mr-auto">
-                    <button
-                      type="button"
-                      className="btn btn-primary payment-button text-nowrap mt-4"
-                      disabled={isSubmitDisabled()}
-                      onClick={() => {
-                        redirectToPayment({
-                          recipientPersonalCode: user.personalCode,
-                          amount: Number(paymentAmount.replace(',', '.')),
-                          currency: 'EUR',
-                          type: paymentType,
-                          paymentChannel: paymentBank.toUpperCase() as PaymentChannel,
-                        });
-                      }}
-                    >
+                  <div className="mt-2">
+                    <small className="text-muted">
                       {paymentType === PaymentType.SINGLE && (
-                        <FormattedMessage id="thirdPillarPayment.makePayment" />
+                        <FormattedMessage
+                          id="thirdPillarPayment.freeSinglePayment"
+                          values={{
+                            b: (chunks: string) => <b>{chunks}</b>,
+                          }}
+                        />
                       )}
                       {paymentType === PaymentType.RECURRING && (
-                        <FormattedMessage id="thirdPillarPayment.setupRecurringPayment" />
+                        <FormattedMessage
+                          id="thirdPillarPayment.freeRecurringPayment"
+                          values={{
+                            b: (chunks: string) => <b>{chunks}</b>,
+                          }}
+                        />
                       )}
-                    </button>
-                    <div className="mt-2">
-                      <small className="text-muted">
-                        {paymentType === PaymentType.SINGLE && (
-                          <FormattedMessage
-                            id="thirdPillarPayment.freeSinglePayment"
-                            values={{
-                              b: (chunks: string) => <b>{chunks}</b>,
-                            }}
-                          />
-                        )}
-                        {paymentType === PaymentType.RECURRING && (
-                          <FormattedMessage
-                            id="thirdPillarPayment.freeRecurringPayment"
-                            values={{
-                              b: (chunks: string) => <b>{chunks}</b>,
-                            }}
-                          />
-                        )}
-                      </small>
-                    </div>
+                    </small>
                   </div>
-                  {paymentType === PaymentType.RECURRING && !isSubmitDisabled() && (
-                    <div className="d-flex flex-wrap align-items-center">
-                      <span className="mr-2 mt-4">
-                        <FormattedMessage id="thirdPillarPayment.recurringPaymentQuestion" />
-                      </span>
-                      <a className="btn btn-light text-nowrap mt-4" href="/account">
-                        <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
-                      </a>
-                    </div>
-                  )}
                 </div>
-              </>
-            )}
-          </div>
-        </>
-      )}
+                {paymentType === PaymentType.RECURRING && !isSubmitDisabled() && (
+                  <div className="d-flex flex-wrap align-items-center">
+                    <span className="mr-2 mt-4">
+                      <FormattedMessage id="thirdPillarPayment.recurringPaymentQuestion" />
+                    </span>
+                    <a className="btn btn-light text-nowrap mt-4" href="/account">
+                      <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
+                    </a>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </>
     </>
   );
 };

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { captureException } from '@sentry/browser';
 import ThirdPillarPaymentsAmount from '../../../account/statusBox/thirdPillarStatusBox/ThirdPillarContributionAmount';
 import './Payment.scss';
 import { redirectToPayment } from '../../../common/api';
@@ -51,6 +52,7 @@ export const Payment: React.FunctionComponent = () => {
       });
     } catch (e) {
       setError(true);
+      captureException(e);
     }
   };
 

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
@@ -19,6 +19,7 @@ export const Payment: React.FunctionComponent = () => {
   const [paymentType, setPaymentType] = useState<AvailablePaymentType>(PaymentType.SINGLE);
   const [paymentAmount, setPaymentAmount] = useState<string>('');
   const [paymentBank, setPaymentBank] = useState<BankKey | 'other' | null>(null);
+  const [error, setError] = useState<boolean>(false);
 
   const { data: user } = useMe();
 
@@ -33,18 +34,24 @@ export const Payment: React.FunctionComponent = () => {
     !paymentAmount ||
     Number(paymentAmount.replace(',', '.')) <= 0;
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
+    setError(false);
+
     if (isSubmitDisabled()) {
       return;
     }
 
-    redirectToPayment({
-      recipientPersonalCode: user.personalCode,
-      amount: Number(paymentAmount.replace(',', '.')),
-      currency: 'EUR',
-      type: paymentType,
-      paymentChannel: paymentBank?.toUpperCase() as PaymentChannel,
-    });
+    try {
+      await redirectToPayment({
+        recipientPersonalCode: user.personalCode,
+        amount: Number(paymentAmount.replace(',', '.')),
+        currency: 'EUR',
+        type: paymentType,
+        paymentChannel: paymentBank?.toUpperCase() as PaymentChannel,
+      });
+    } catch (e) {
+      setError(true);
+    }
   };
 
   return (
@@ -52,6 +59,11 @@ export const Payment: React.FunctionComponent = () => {
       <h2 className="mt-3">
         <FormattedMessage id="thirdPillarPayment.title" />
       </h2>
+      {error && (
+        <div className="alert alert-danger mt-5" role="alert">
+          <FormattedMessage id="thirdPillarPayment.errorGeneratingLink" />
+        </div>
+      )}
       <PaymentTypeSelection paymentType={paymentType} setPaymentType={setPaymentType} />
       <>
         <PaymentAmountInput

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentBankButtons.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentBankButtons.tsx
@@ -1,0 +1,20 @@
+import { BankButton } from './BankButton';
+import { BankKey } from './types';
+
+type Props = {
+  paymentBank: BankKey | 'other' | null;
+  setPaymentBank: (value: BankKey | 'other' | null) => unknown;
+};
+
+export const PaymentBankButtons = ({ paymentBank, setPaymentBank }: Props) => (
+  <>
+    <div className="mt-2 payment-banks">
+      <BankButton bankKey="swedbank" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+      <BankButton bankKey="seb" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+      <BankButton bankKey="lhv" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+      <BankButton bankKey="luminor" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+      <BankButton bankKey="coop" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+      <BankButton bankKey="other" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+    </div>
+  </>
+);

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentSubmitSection.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentSubmitSection.tsx
@@ -1,0 +1,85 @@
+import { Link } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
+import './Payment.scss';
+import { PaymentType } from '../../../common/apiModels';
+import { AvailablePaymentType, BankKey } from './types';
+
+type Props = {
+  paymentBank: BankKey | 'other' | null;
+  paymentType: AvailablePaymentType;
+  handleSubmit: () => unknown;
+  disabled: boolean;
+};
+export const PaymentSubmitSection = ({
+  paymentBank,
+  paymentType,
+  handleSubmit,
+  disabled,
+}: Props) => {
+  if (paymentBank === null) {
+    return null;
+  }
+
+  if (paymentBank === 'other') {
+    return (
+      <div className="mt-4">
+        <Link to="/account">
+          <button type="button" className="btn btn-light">
+            <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
+          </button>
+        </Link>
+      </div>
+    );
+  }
+  return (
+    <>
+      <div className="d-flex flex-wrap align-items-start">
+        <div className="mr-auto">
+          <button
+            type="button"
+            className="btn btn-primary payment-button text-nowrap mt-4"
+            disabled={disabled}
+            onClick={handleSubmit}
+          >
+            {paymentType === PaymentType.SINGLE && (
+              <FormattedMessage id="thirdPillarPayment.makePayment" />
+            )}
+            {paymentType === PaymentType.RECURRING && (
+              <FormattedMessage id="thirdPillarPayment.setupRecurringPayment" />
+            )}
+          </button>
+          <div className="mt-2">
+            <small className="text-muted">
+              {paymentType === PaymentType.SINGLE && (
+                <FormattedMessage
+                  id="thirdPillarPayment.freeSinglePayment"
+                  values={{
+                    b: (chunks: string) => <b>{chunks}</b>,
+                  }}
+                />
+              )}
+              {paymentType === PaymentType.RECURRING && (
+                <FormattedMessage
+                  id="thirdPillarPayment.freeRecurringPayment"
+                  values={{
+                    b: (chunks: string) => <b>{chunks}</b>,
+                  }}
+                />
+              )}
+            </small>
+          </div>
+        </div>
+        {paymentType === PaymentType.RECURRING && !disabled && (
+          <div className="d-flex flex-wrap align-items-center">
+            <span className="mr-2 mt-4">
+              <FormattedMessage id="thirdPillarPayment.recurringPaymentQuestion" />
+            </span>
+            <a className="btn btn-light text-nowrap mt-4" href="/account">
+              <FormattedMessage id="thirdPillarPayment.backToAccountPage" />
+            </a>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentSubmitSection.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentSubmitSection.tsx
@@ -16,10 +16,6 @@ export const PaymentSubmitSection = ({
   handleSubmit,
   disabled,
 }: Props) => {
-  if (paymentBank === null) {
-    return null;
-  }
-
   if (paymentBank === 'other') {
     return (
       <div className="mt-4">

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentTypeSelection.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/PaymentTypeSelection.tsx
@@ -1,0 +1,46 @@
+import { FormattedMessage } from 'react-intl';
+import { Radio } from '../../../common';
+import './Payment.scss';
+import { PaymentType } from '../../../common/apiModels';
+import { AvailablePaymentType } from './types';
+
+type Props = {
+  paymentType: AvailablePaymentType;
+  setPaymentType: (value: AvailablePaymentType) => unknown;
+};
+
+export const PaymentTypeSelection = ({ paymentType, setPaymentType }: Props) => (
+  <>
+    <div className="mt-5">
+      <b>
+        <FormattedMessage id="thirdPillarPayment.paymentType" />
+      </b>
+    </div>
+    <Radio
+      name="payment-type"
+      id="payment-type-single"
+      className="mt-3 p-3"
+      selected={paymentType === PaymentType.SINGLE}
+      onSelect={() => {
+        setPaymentType(PaymentType.SINGLE);
+      }}
+    >
+      <p className="m-0">
+        <FormattedMessage id="thirdPillarPayment.SINGLE" />
+      </p>
+    </Radio>
+    <Radio
+      name="payment-type"
+      id="payment-type-recurring"
+      className="mt-3"
+      selected={paymentType === PaymentType.RECURRING}
+      onSelect={() => {
+        setPaymentType(PaymentType.RECURRING);
+      }}
+    >
+      <p className="m-0">
+        <FormattedMessage id="thirdPillarPayment.RECURRING" />
+      </p>
+    </Radio>
+  </>
+);

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/RecurringPaymentDetails.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/RecurringPaymentDetails.tsx
@@ -1,0 +1,39 @@
+import './Payment.scss';
+import { PaymentType } from '../../../common/apiModels';
+import { LuminorRecurringPaymentDetails } from './paymentDetails/LuminorRecurringPaymentDetails';
+import { OtherBankPaymentDetails } from './paymentDetails/OtherBankPaymentDetails';
+import { SwedbankRecurringPaymentDetails } from './paymentDetails/SwedbankRecurringPaymentDetails';
+import { SebRecurringPaymentDetails } from './paymentDetails/SebRecurringPaymentDetails';
+import { LhvRecurringPaymentDetails } from './paymentDetails/LhvRecurringPaymentDetails';
+import { CoopRecurringPaymentDetails } from './paymentDetails/CoopRecurringPaymentDetails';
+import { BankKey } from './types';
+
+type Props = {
+  paymentBank: BankKey | 'other';
+  paymentAmount: string;
+  personalCode: string;
+};
+
+export const RecurringPaymentDetails = ({ paymentBank, paymentAmount, personalCode }: Props) => (
+  <>
+    {paymentBank === 'swedbank' && <SwedbankRecurringPaymentDetails amount={paymentAmount} />}
+
+    {paymentBank === 'seb' && <SebRecurringPaymentDetails />}
+
+    {paymentBank === 'lhv' && <LhvRecurringPaymentDetails />}
+
+    {paymentBank === 'luminor' && (
+      <LuminorRecurringPaymentDetails amount={paymentAmount} personalCode={personalCode} />
+    )}
+
+    {paymentBank === 'coop' && <CoopRecurringPaymentDetails />}
+
+    {paymentBank === 'other' && (
+      <OtherBankPaymentDetails
+        personalCode={personalCode}
+        amount={paymentAmount}
+        paymentType={PaymentType.RECURRING}
+      />
+    )}
+  </>
+);

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
@@ -17,14 +17,35 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
   const [paymentPersonalCode, setPaymentPersonalCode] = useState<string>('');
   const [paymentAmount, setPaymentAmount] = useState<string>('');
   const [paymentBank, setPaymentBank] = useState<BankKey | 'other' | null>(null);
+  const [error, setError] = useState<boolean>(false);
 
-  const isDisabled = () =>
+  const isSubmitDisabled = () =>
     !paymentPersonalCode ||
     !isValidPersonalCode(paymentPersonalCode) ||
     !paymentBank ||
     paymentBank === 'other' ||
     !paymentAmount ||
     Number(paymentAmount.replace(',', '.')) <= 0;
+
+  const handleSubmit = async () => {
+    setError(false);
+
+    if (isSubmitDisabled()) {
+      return;
+    }
+
+    try {
+      await redirectToPayment({
+        recipientPersonalCode: paymentPersonalCode,
+        amount: Number(paymentAmount.replace(',', '.')),
+        currency: 'EUR',
+        type: PaymentType.GIFT,
+        paymentChannel: paymentBank?.toUpperCase() as PaymentChannel,
+      });
+    } catch (e) {
+      setError(true);
+    }
+  };
 
   return (
     <>
@@ -40,6 +61,11 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
           }}
         />
       </p>
+      {error && (
+        <div className="alert alert-danger mt-3" role="alert">
+          <FormattedMessage id="thirdPillarPayment.errorGeneratingLink" />
+        </div>
+      )}
 
       <div>
         <label className="mt-3" htmlFor="payment-personal-code">
@@ -127,16 +153,8 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
               <button
                 type="button"
                 className="btn btn-primary payment-button text-nowrap mt-4"
-                disabled={isDisabled()}
-                onClick={() => {
-                  redirectToPayment({
-                    recipientPersonalCode: paymentPersonalCode,
-                    amount: Number(paymentAmount.replace(',', '.')),
-                    currency: 'EUR',
-                    type: PaymentType.GIFT,
-                    paymentChannel: paymentBank?.toUpperCase() as PaymentChannel,
-                  });
-                }}
+                disabled={isSubmitDisabled()}
+                onClick={handleSubmit}
               >
                 <FormattedMessage id="thirdPillarPayment.makePayment" />
               </button>

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
@@ -89,6 +89,7 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
       </div>
 
       <div className="mt-2 payment-banks">
+        {/* TODO use refactored PaymentBankButtons here */}
         <BankButton bankKey="swedbank" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
         <BankButton bankKey="seb" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
         <BankButton bankKey="lhv" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
@@ -9,13 +9,14 @@ import { PaymentChannel, PaymentType } from '../../../common/apiModels';
 import { PaymentAmountInput } from './PaymentAmountInput';
 import { OtherBankPaymentDetails } from './paymentDetails/OtherBankPaymentDetails';
 import { isValidPersonalCode } from './PersonalCode';
+import { BankKey } from './types';
 
 export const ThirdPillarGift: React.FunctionComponent = () => {
   const { formatMessage } = useIntl();
 
   const [paymentPersonalCode, setPaymentPersonalCode] = useState<string>('');
   const [paymentAmount, setPaymentAmount] = useState<string>('');
-  const [paymentBank, setPaymentBank] = useState<string>('');
+  const [paymentBank, setPaymentBank] = useState<BankKey | 'other' | null>(null);
 
   const isDisabled = () =>
     !paymentPersonalCode ||
@@ -88,33 +89,12 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
       </div>
 
       <div className="mt-2 payment-banks">
-        <BankButton
-          bankKey="swedbank"
-          bankName="Swedbank"
-          paymentBank={paymentBank}
-          setPaymentBank={setPaymentBank}
-        />
-        <BankButton
-          bankKey="seb"
-          bankName="SEB"
-          paymentBank={paymentBank}
-          setPaymentBank={setPaymentBank}
-        />
-        <BankButton
-          bankKey="lhv"
-          bankName="LHV"
-          paymentBank={paymentBank}
-          setPaymentBank={setPaymentBank}
-        />
-        <BankButton
-          bankKey="luminor"
-          bankName="Luminor"
-          paymentBank={paymentBank}
-          setPaymentBank={setPaymentBank}
-        />
+        <BankButton bankKey="swedbank" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+        <BankButton bankKey="seb" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+        <BankButton bankKey="lhv" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
+        <BankButton bankKey="luminor" paymentBank={paymentBank} setPaymentBank={setPaymentBank} />
         <BankButton
           bankKey="other"
-          bankName={formatMessage({ id: 'thirdPillarPayment.otherBank' })}
           paymentBank={paymentBank}
           setPaymentBank={setPaymentBank}
           disabled={!paymentPersonalCode || !isValidPersonalCode(paymentPersonalCode)}
@@ -153,7 +133,7 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
                     amount: Number(paymentAmount.replace(',', '.')),
                     currency: 'EUR',
                     type: PaymentType.GIFT,
-                    paymentChannel: paymentBank.toUpperCase() as PaymentChannel,
+                    paymentChannel: paymentBank?.toUpperCase() as PaymentChannel,
                   });
                 }}
               >

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarGift.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import './Payment.scss';
+import { captureException } from '@sentry/browser';
 import { BankButton } from './BankButton';
 import { redirectToPayment } from '../../../common/api';
 import { PaymentChannel, PaymentType } from '../../../common/apiModels';
@@ -44,6 +45,7 @@ export const ThirdPillarGift: React.FunctionComponent = () => {
       });
     } catch (e) {
       setError(true);
+      captureException(e);
     }
   };
 

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/types.ts
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/types.ts
@@ -1,0 +1,13 @@
+import { PaymentType } from '../../../common/apiModels';
+
+export type AvailablePaymentType = PaymentType.SINGLE | PaymentType.RECURRING;
+
+export const bankKeyToBankNameMap = {
+  swedbank: 'Swedbank',
+  seb: 'SEB',
+  lhv: 'LHV',
+  luminor: 'Luminor',
+  coop: 'Coop Pank',
+} as const;
+
+export type BankKey = keyof typeof bankKeyToBankNameMap;

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -257,7 +257,6 @@
   "account.status.choice.pillar.second.feecard.title": "Low Fees",
   "account.status.choice.pillar.second.feecard.text": "You accumulate in Tuleva's II pillar funds with <b>low fees</b>",
 
-
   "account.status.choice.pillar.third": "III pillar",
   "account.status.choice.pillar.third.missing.action": "Open III pillar",
   "account.status.choice.pillar.third.missing.label": "You have not opened your III pillar yet",
@@ -474,6 +473,7 @@
   "thirdPillarPayment.accountNumber.luminor": "Estonian Pension Registry's Luminor account number",
   "thirdPillarPayment.processingCodeAndPersonalCode": "III pillar processing code, personal code and Tuleva III Pillar Pension Fund ISIN",
   "thirdPillarPayment.pensionAccountNumber": "Your pension account number",
+  "thirdPillarPayment.errorGeneratingLink": "There was an error generating the payment link. Please try again later or contact us",
 
   "thirdPillarPayment.EMPLOYER.title": "Application to the employer to pay directly from the salary to III pillar",
   "thirdPillarPayment.EMPLOYER.publicEmployer": "I'm a public sector employee",
@@ -665,11 +665,11 @@
 
   "comparisonCalculator.content.performance.cta.subtext": "Tuleva World Stock Pension Fund follows the world market index, it tries to achieve a long-term return as similar as possible to it.",
 
-  "comparisonCalculator.ctaButton" : "Bring your {pillar} pillar to Tuleva",
-  "comparisonCalculator.graphWorldMarketStockIndex" : "World market index",
-  "comparisonCalculator.graphYourIIPillar" : "Your II pillar",
-  "comparisonCalculator.graphYourIIIPillar" : "Your III pillar",
-  "comparisonCalculator.footerDisclaimer" : "Percentages show, how much has your II pillar on average grown per year. Euros show the last {years} year total growth.",
+  "comparisonCalculator.ctaButton": "Bring your {pillar} pillar to Tuleva",
+  "comparisonCalculator.graphWorldMarketStockIndex": "World market index",
+  "comparisonCalculator.graphYourIIPillar": "Your II pillar",
+  "comparisonCalculator.graphYourIIIPillar": "Your III pillar",
+  "comparisonCalculator.footerDisclaimer": "Percentages show, how much has your II pillar on average grown per year. Euros show the last {years} year total growth.",
   "comparisonCalculator.footerNumbersExplanationLink": "What do these numbers mean?",
   "comparisonCalculator.footerPerformanceExplanationLink": "What returns to expect in Tuleva?",
   "comparisonCalculator.period.all": "From starting {pillar} contributions ({date})",
@@ -682,8 +682,6 @@
   "comparisonCalculator.period.threeYears": "Last 3 years",
   "comparisonCalculator.period.twoYears": "Last 2 years",
   "comparisonCalculator.period.oneYear": "Last year",
-
-
 
   "LHV Pensionifond XL": "Pension Fund LHV XL",
   "Tuleva Maailma Aktsiate Pensionifond": "Tuleva World Stocks Pension Fund",

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -473,7 +473,7 @@
   "thirdPillarPayment.accountNumber.luminor": "Estonian Pension Registry's Luminor account number",
   "thirdPillarPayment.processingCodeAndPersonalCode": "III pillar processing code, personal code and Tuleva III Pillar Pension Fund ISIN",
   "thirdPillarPayment.pensionAccountNumber": "Your pension account number",
-  "thirdPillarPayment.errorGeneratingLink": "There was an error generating the payment link. Please try again later or contact us",
+  "thirdPillarPayment.errorGeneratingLink": "There was an error initiating the payment. Please try again later or contact us: tuleva@tuleva.ee",
 
   "thirdPillarPayment.EMPLOYER.title": "Application to the employer to pay directly from the salary to III pillar",
   "thirdPillarPayment.EMPLOYER.publicEmployer": "I'm a public sector employee",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -256,7 +256,7 @@
   "account.status.choice.pillar.second.feecard.title": "Madalad tasud",
   "account.status.choice.pillar.second.feecard.text": "Tuleva II samba fondides kogud <b>madalate tasudega</b>",
 
-"account.status.choice.pillar.third": "III sammas",
+  "account.status.choice.pillar.third": "III sammas",
   "account.status.choice.pillar.third.missing.action": "Ava III sammas",
   "account.status.choice.pillar.third.missing.label": "Sul pole III sammas veel avatud",
   "account.status.choice.pillar.third.inactive.action": "Vali Tuleva",
@@ -475,6 +475,7 @@
   "thirdPillarPayment.accountNumber.luminor": "Pensionikeskuse Luminori kontonumber",
   "thirdPillarPayment.processingCodeAndPersonalCode": "III sammast tähistav töötluskood, isikukood ja Tuleva III Samba Pensionifondi ISIN",
   "thirdPillarPayment.pensionAccountNumber": "Sinu personaalne pensionikonto number",
+  "thirdPillarPayment.errorGeneratingLink": "Makselingi genereerimisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust",
 
   "thirdPillarPayment.EMPLOYER.title": "Avaldus tööandjale otse palgast III sambasse maksmiseks",
   "thirdPillarPayment.EMPLOYER.publicEmployer": "Olen avaliku sektori töötaja",
@@ -633,7 +634,6 @@
   "comparisonCalculator.comparisonOptions.epi": "Eesti keskmine II samba fond",
   "comparisonCalculator.comparisonOptions.cpi": "Eesti inflatsioon",
 
-
   "comparisonCalculator.content.performance.index.alpha.start": "Sinu {pillar} sammas on viimase {years} aastaga <b>maailmaturu indeksi</b>",
   "comparisonCalculator.content.performance.index.alpha.wordNegative": "tootlusele",
   "comparisonCalculator.content.performance.index.alpha.wordPositive": "tootlust",
@@ -667,11 +667,11 @@
 
   "comparisonCalculator.content.performance.cta.subtext": "Tuleva Maailma Aktsiate Pensionifond järgib maailmaturu indeksit, st püüab saavutada sellega võimalikult sarnast pikaajalist tootlust.",
 
-  "comparisonCalculator.ctaButton" : "Too oma {pillar} sammas Tulevasse",
-  "comparisonCalculator.graphWorldMarketStockIndex" : "Maailmaturu indeks",
-  "comparisonCalculator.graphYourIIPillar" : "Sinu II sammas",
-  "comparisonCalculator.graphYourIIIPillar" : "Sinu III sammas",
-  "comparisonCalculator.footerDisclaimer" : "Protsendid näitavad, kui palju on sinu pensionisammas kasvanud keskmiselt igal aastal. Eurod näitavad kogukasvu valitud ajaperioodil.",
+  "comparisonCalculator.ctaButton": "Too oma {pillar} sammas Tulevasse",
+  "comparisonCalculator.graphWorldMarketStockIndex": "Maailmaturu indeks",
+  "comparisonCalculator.graphYourIIPillar": "Sinu II sammas",
+  "comparisonCalculator.graphYourIIIPillar": "Sinu III sammas",
+  "comparisonCalculator.footerDisclaimer": "Protsendid näitavad, kui palju on sinu pensionisammas kasvanud keskmiselt igal aastal. Eurod näitavad kogukasvu valitud ajaperioodil.",
   "comparisonCalculator.footerNumbersExplanationLink": "Mida need arvud näitavad?",
   "comparisonCalculator.footerPerformanceExplanationLink": "Millist tootlust on Tulevas oodata?",
   "comparisonCalculator.period.all": "Kogumise algusest {pillar} sambas ({date})",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -475,7 +475,7 @@
   "thirdPillarPayment.accountNumber.luminor": "Pensionikeskuse Luminori kontonumber",
   "thirdPillarPayment.processingCodeAndPersonalCode": "III sammast tähistav töötluskood, isikukood ja Tuleva III Samba Pensionifondi ISIN",
   "thirdPillarPayment.pensionAccountNumber": "Sinu personaalne pensionikonto number",
-  "thirdPillarPayment.errorGeneratingLink": "Makselingi genereerimisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust",
+  "thirdPillarPayment.errorGeneratingLink": "Makse algatamisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust: tuleva@tuleva.ee",
 
   "thirdPillarPayment.EMPLOYER.title": "Avaldus tööandjale otse palgast III sambasse maksmiseks",
   "thirdPillarPayment.EMPLOYER.publicEmployer": "Olen avaliku sektori töötaja",


### PR DESCRIPTION
Adds error handling to 3rd pillar payment flow, as the link generation now includes an API call, it can now fail.
Refactors 3rd pillar payment section, splitting single big component to smaller ones.
Removes employer payment type for now, as it was dead code.

<img width="1007" alt="Screenshot 2024-07-08 at 08 46 05" src="https://github.com/TulevaEE/onboarding-client/assets/3755903/818c853d-0aee-4b93-a593-a4e45e26c8f4">
<img width="983" alt="Screenshot 2024-07-08 at 08 45 53" src="https://github.com/TulevaEE/onboarding-client/assets/3755903/f5a1475f-24a1-41a1-96a9-b66bfa9781d6">

