### PR TITLE
Check if user has II pillar payment rate application already done in II pillar flow, before suggesting increasing it

### DIFF
--- a/src/components/common/apiModels.ts
+++ b/src/components/common/apiModels.ts
@@ -167,7 +167,7 @@ interface Address {
 
 interface PaymentRates {
   current: PaymentRate;
-  pending: PaymentRate;
+  pending: PaymentRate | null;
 }
 
 export interface User {

--- a/src/components/flows/secondPillar/success/Success.tsx
+++ b/src/components/flows/secondPillar/success/Success.tsx
@@ -8,6 +8,7 @@ import { State } from '../../../../types';
 import { Notice } from '../../common/Notice/Notice';
 import whatshot from './whatshot.svg';
 import { BackToInternetBankButton } from '../../partner/BackToPartner/BackToInternetBankButton';
+import { useMe } from '../../../common/apiHooks';
 
 interface Props {
   userContributingFuturePayments: boolean;
@@ -17,71 +18,81 @@ interface Props {
 export const Success: React.FC<Props> = ({
   userContributingFuturePayments,
   userHasTransferredFunds,
-}) => (
-  <>
-    <SuccessNotice2>
-      <h2 className="my-3">
-        <FormattedMessage id="success.done" />
-      </h2>
-      {userHasTransferredFunds && (
-        <p>
-          <FormattedMessage
-            id="success.shares.switched"
-            values={{
-              b: (chunks: string) => <b>{chunks}</b>,
-              transferDate: secondPillarTransferDate().format('DD.MM.YYYY'),
-            }}
-          />
-        </p>
-      )}
-      {userContributingFuturePayments && (
-        <p>
-          <FormattedMessage
-            id="success.your.payments"
-            values={{
-              b: (chunks: string) => <b>{chunks}</b>,
-            }}
-          />
-        </p>
-      )}
+}) => {
+  const { data: user, isLoading } = useMe();
 
-      <div className="d-flex justify-content-center mt-4">
-        <a className="btn btn-outline-primary flex-grow-1 flex-md-grow-0" href="/account">
-          <FormattedMessage id="success.backToAccount" />
-        </a>
-      </div>
-      <BackToInternetBankButton />
-    </SuccessNotice2>
-    <Notice>
-      <img src={whatshot} alt="" />
-      <h2 className="my-3">
-        <FormattedMessage id="success.2ndPillarPaymentUpsell.title" />
-      </h2>
-      <p className="mt-3">
-        <FormattedMessage
-          id="success.2ndPillarPaymentUpsell.content"
-          values={{
-            b: (chunks: string) => <b>{chunks}</b>,
-          }}
-        />
-      </p>
-      <div className="mt-3 small">
-        <FormattedMessage id="success.2ndPillarPaymentUpsell.small" />
-      </div>
-      <div className="d-flex justify-content-center mt-4">
-        <Link
-          to="/2nd-pillar-payment-rate"
-          className="btn btn-primary btn-lg flex-grow-1 flex-md-grow-0"
-        >
-          <FormattedMessage id="success.2ndPillarPaymentUpsell.button" />
-        </Link>
-      </div>
-      <div className="mt-2 small text-muted">
-        <FormattedMessage id="success.2ndPillarPaymentUpsell.disclaimer" />
-      </div>
-    </Notice>
-  </>
-);
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <>
+      <SuccessNotice2>
+        <h2 className="my-3">
+          <FormattedMessage id="success.done" />
+        </h2>
+        {userHasTransferredFunds && (
+          <p>
+            <FormattedMessage
+              id="success.shares.switched"
+              values={{
+                b: (chunks: string) => <b>{chunks}</b>,
+                transferDate: secondPillarTransferDate().format('DD.MM.YYYY'),
+              }}
+            />
+          </p>
+        )}
+        {userContributingFuturePayments && (
+          <p>
+            <FormattedMessage
+              id="success.your.payments"
+              values={{
+                b: (chunks: string) => <b>{chunks}</b>,
+              }}
+            />
+          </p>
+        )}
+
+        <div className="d-flex justify-content-center mt-4">
+          <a className="btn btn-outline-primary flex-grow-1 flex-md-grow-0" href="/account">
+            <FormattedMessage id="success.backToAccount" />
+          </a>
+        </div>
+        <BackToInternetBankButton />
+      </SuccessNotice2>
+      {user?.secondPillarPaymentRates.current === 2 && !user?.secondPillarPaymentRates.pending && (
+        <Notice>
+          <img src={whatshot} alt="" />
+          <h2 className="my-3">
+            <FormattedMessage id="success.2ndPillarPaymentUpsell.title" />
+          </h2>
+          <p className="mt-3">
+            <FormattedMessage
+              id="success.2ndPillarPaymentUpsell.content"
+              values={{
+                b: (chunks: string) => <b>{chunks}</b>,
+              }}
+            />
+          </p>
+          <div className="mt-3 small">
+            <FormattedMessage id="success.2ndPillarPaymentUpsell.small" />
+          </div>
+          <div className="d-flex justify-content-center mt-4">
+            <Link
+              to="/2nd-pillar-payment-rate"
+              className="btn btn-primary btn-lg flex-grow-1 flex-md-grow-0"
+            >
+              <FormattedMessage id="success.2ndPillarPaymentUpsell.button" />
+            </Link>
+          </div>
+          <div className="mt-2 small text-muted">
+            <FormattedMessage id="success.2ndPillarPaymentUpsell.disclaimer" />
+          </div>
+        </Notice>
+      )}
+    </>
+  );
+};
 
 const mapStateToProps = (state: State) => ({
   userContributingFuturePayments: !!state.exchange.selectedFutureContributionsFundIsin,


### PR DESCRIPTION
If user just completed the II pillar flow, 
* and their current contribution rate is 2% 
* and they don't have a pending payment rate application

don't suggest increasing the payment rate.

Old state, when rate had already been increased
![Screenshot 2024-08-26 at 12 25 57](https://github.com/user-attachments/assets/32c9fe49-8228-4f97-aed2-8c1e6fbf1c36)

New state, when rate has already been increased
![Screenshot 2024-08-26 at 12 53 21](https://github.com/user-attachments/assets/c24fa5c7-3c9f-4403-a403-55fbc9b36b2b)
