### PR TITLE
Fix typos and improve RTL tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## Tech evolution
 
-Originally, this repo was built using js, redux and enzyme for testing. Over the years react has grown, rendering some of these tehcnologies less useful. This architecture has shown itself to be overcomplicated and the current tests to not give as much value as they could. Thus, whenever you are working on new functionality in this repo, try to do the following:
+Originally, this repo was built using js, redux and enzyme for testing. Over the years react has grown, rendering some of these technologies less useful. This architecture has shown itself to be overcomplicated and the current tests to not give as much value as they could. Thus, whenever you are working on new functionality in this repo, try to do the following:
 
-- Convert files you touch to typescript, this can be easily done as typescript and js can be used interchangably in this repo.
+- Convert files you touch to typescript, this can be easily done as typescript and js can be used interchangeably in this repo.
 - Convert class components to functional if possible.
 - Try to not use Redux (See below)
 - Use react testing library and msw for tests and try to mock as little as possible, building tests to imitate how a user would use your application. See the [`CancellationFlow`](./src/components/flows/cancellation/CancellationFlow.tsx) for an example of how to incrementally move to this structure while reusing previous redux code.

--- a/src/components/LoggedInApp/header/languageSwitcher/LanguageSwitcher.test.tsx
+++ b/src/components/LoggedInApp/header/languageSwitcher/LanguageSwitcher.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import config from 'react-global-configuration';
 
 import LanguageSwitcher from '.';
@@ -10,16 +10,16 @@ describe('Language Switcher', () => {
   it('can switch to English when the language is Estonian', () => {
     config.set({ language: 'et' }, options);
 
-    const language = shallow(<LanguageSwitcher />).text();
+    render(<LanguageSwitcher />);
 
-    expect(language).toBe('EN');
+    expect(screen.getByText('EN')).toBeInTheDocument();
   });
 
   it('can switch to Estonian when the language is English', () => {
     config.set({ language: 'en' }, options);
 
-    const language = shallow(<LanguageSwitcher />).text();
+    render(<LanguageSwitcher />);
 
-    expect(language).toBe('ET');
+    expect(screen.getByText('ET')).toBeInTheDocument();
   });
 });

--- a/src/components/account/statusBox/statusBoxRow/StatusBoxRow.tsx
+++ b/src/components/account/statusBox/statusBoxRow/StatusBoxRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-// TODO refac props to union type of 'SUCCESS' | 'ERROR' | 'WARNING'
+// TODO refactor props to union type of 'SUCCESS' | 'ERROR' | 'WARNING'
 const StatusBoxIcon: React.FunctionComponent<{
   checked?: boolean;
   warning?: boolean;

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -27,6 +27,7 @@ if (isProduction) {
 
 /* eslint-disable no-extend-native */
 if (!String.prototype.startsWith) {
-  String.prototype.startsWith = (search, pos) =>
-    this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
+  String.prototype.startsWith = function (search, pos) {
+    return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
+  };
 }


### PR DESCRIPTION
## Summary
- fix README misspellings
- correct String.startsWith polyfill
- clarify StatusBoxRow TODO comment
- convert LanguageSwitcher test to React Testing Library

## Testing
- `npm test`