### PR TITLE
Fix typos and improve third pillar logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## Tech evolution
 
-Originally, this repo was built using js, redux and enzyme for testing. Over the years react has grown, rendering some of these tehcnologies less useful. This architecture has shown itself to be overcomplicated and the current tests to not give as much value as they could. Thus, whenever you are working on new functionality in this repo, try to do the following:
+Originally, this repo was built using js, redux and enzyme for testing. Over the years react has grown, rendering some of these technologies less useful. This architecture has shown itself to be overcomplicated and the current tests to not give as much value as they could. Thus, whenever you are working on new functionality in this repo, try to do the following:
 
-- Convert files you touch to typescript, this can be easily done as typescript and js can be used interchangably in this repo.
+- Convert files you touch to typescript, this can be easily done as typescript and js can be used interchangeably in this repo.
 - Convert class components to functional if possible.
 - Try to not use Redux (See below)
 - Use react testing library and msw for tests and try to mock as little as possible, building tests to imitate how a user would use your application. See the [`CancellationFlow`](./src/components/flows/cancellation/CancellationFlow.tsx) for an example of how to incrementally move to this structure while reusing previous redux code.

--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.test.tsx
@@ -172,4 +172,19 @@ describe('ThirdPillarStatusBox', () => {
     });
     expect(component).toMatchSnapshot();
   });
+
+  it('shows high fee notice when balance is zero but active fund has high fee', () => {
+    component.setProps({
+      conversion: {
+        selectionPartial: false,
+        selectionComplete: false,
+        transfersPartial: false,
+        transfersComplete: false,
+        contribution: { yearToDate: 0, total: 0 },
+        weightedAverageFee: 0,
+      },
+      thirdPillarFunds: [highFeeThirdPillar],
+    });
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.tsx
+++ b/src/components/account/statusBox/thirdPillarStatusBox/ThirdPillarStatusBox.tsx
@@ -121,7 +121,12 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
 
   const isPartiallyConverted = conversion.selectionPartial || conversion.transfersPartial;
   if (!isPartiallyConverted) {
-    if (conversion.weightedAverageFee > 0.005) {
+    const activeFundFee = activeFund?.ongoingChargesFigure || 0;
+    const hasHighFees =
+      conversion.weightedAverageFee > 0.005 ||
+      (conversion.contribution.total === 0 && activeFundFee > 0.005);
+
+    if (hasHighFees) {
       return (
         <StatusBoxRow
           error
@@ -144,7 +149,6 @@ export const ThirdPillarStatusBox: React.FunctionComponent<Props> = ({
       );
     }
     return (
-      // TODO: bug - if fund balance is 0, it always shows this message. rather, it should then consider the active fund fee
       <StatusBoxRow
         ok
         showAction={!loading}

--- a/src/components/account/statusBox/thirdPillarStatusBox/__snapshots__/ThirdPillarStatusBox.test.tsx.snap
+++ b/src/components/account/statusBox/thirdPillarStatusBox/__snapshots__/ThirdPillarStatusBox.test.tsx.snap
@@ -396,3 +396,41 @@ exports[`ThirdPillarStatusBox renders the success flow when funds have not trans
   </Link>
 </StatusBoxRow>
 `;
+
+exports[`ThirdPillarStatusBox shows high fee notice when balance is zero but active fund has high fee 1`] = `
+<StatusBoxRow
+  error={true}
+  lines={
+    Array [
+      <React.Fragment>
+        <Memo(MemoizedFormattedMessage)
+          id="account.status.choice.highFee.label"
+        />
+        <InfoTooltip
+          name="third-pillar-tooltip"
+        >
+          <Memo(MemoizedFormattedMessage)
+            id="account.status.choice.highFee.description"
+          />
+        </InfoTooltip>
+      </React.Fragment>,
+      <Memo(Connect(ThirdPillarContributionAmount)) />,
+    ]
+  }
+  name={
+    <Memo(MemoizedFormattedMessage)
+      id="account.status.choice.pillar.third"
+    />
+  }
+  showAction={true}
+>
+  <Link
+    className="btn btn-primary"
+    to="/3rd-pillar-flow"
+  >
+    <MemoizedFormattedMessage
+      id="account.status.choice.choose.low.fees"
+    />
+  </Link>
+</StatusBoxRow>
+`;

--- a/src/components/common/requestMocker/README.md
+++ b/src/components/common/requestMocker/README.md
@@ -5,7 +5,7 @@ How to use mocking
 1. Add `?development` to URL
 2. Select profiles from the right hand side menu.
 3. Click apply and reload to use them.
-4.
+4. Use the **Clear and close** button to reset mocked responses.
 
 How to add mocked request
 

--- a/src/components/flows/secondPillar/selectSources/targetFundSelector/TargetFundSelector.spec.js
+++ b/src/components/flows/secondPillar/selectSources/targetFundSelector/TargetFundSelector.spec.js
@@ -26,9 +26,11 @@ describe('Target fund selector', () => {
     ];
     component.setProps({ targetFunds, isSelected: jest.fn() });
     expect(component.find('button').length).toBe(3);
-    targetFunds.forEach((fund) => {
+    targetFunds.forEach((fund, index) => {
       expect(component.contains(fund.name)).toBe(true);
-      // TODO: add test for terms link once we have the links.
+      expect(component.find('a.tv-target-fund__terms-link').at(index).prop('href')).toEqual(
+        `target.funds.${fund.isin}.terms.link`,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- fix a couple of typos in the project README
- document the clear/reset step in requestMocker README
- adjust ThirdPillarStatusBox logic to check active fund fee when balance is zero
- test the zero-balance fee case
- verify terms links in TargetFundSelector tests

## Testing
- `npm run update-snapshot`