### PR TITLE
Add static savings fund payment success page

### DIFF
--- a/src/components/LoggedInApp/LoggedInApp.js
+++ b/src/components/LoggedInApp/LoggedInApp.js
@@ -49,6 +49,7 @@ import { CapitalTransferStatus } from '../listings/transfer/status/CapitalTransf
 import { CreateCapitalTransfer } from '../listings/transfer/create/CreateCapitalTransfer';
 import { SavingsFundOnboarding } from '../flows/savingsAccount/SavingsFundOnboarding';
 import { SavingsFundPayment } from '../flows/savingsAccount/SavingsFundPayment';
+import SavingsFundPaymentSuccess from '../flows/savingsAccount/SavingsFundPayment/SavingsFundPaymentSuccess';
 
 export const ACCOUNT_PATH = '/account';
 export const AML_PATH = '/aml';
@@ -202,6 +203,14 @@ export class LoggedInApp extends PureComponent {
               render={() => (
                 <MembersOnlyGatekeep>
                   <CapitalPage />
+                </MembersOnlyGatekeep>
+              )}
+            />
+            <Route
+              path="/savings-fund/payment/success"
+              render={() => (
+                <MembersOnlyGatekeep>
+                  <SavingsFundPaymentSuccess />
                 </MembersOnlyGatekeep>
               )}
             />

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPaymentSuccess.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPaymentSuccess.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { usePageTitle } from '../../../common/usePageTitle';
+import { SuccessNotice2 } from '../../common/SuccessNotice2/SuccessNotice2';
+
+const SavingsFundPaymentSuccess: FC = () => {
+  usePageTitle('savingsFund.payment.success.pageTitle');
+
+  return (
+    <div className="col-12 col-md-10 col-lg-7 mx-auto d-flex flex-column gap-5">
+      <SuccessNotice2>
+        <h2 className="my-3">
+          <FormattedMessage id="savingsFund.payment.success.title" />
+        </h2>
+
+        <p>
+          <FormattedMessage id="savingsFund.payment.success.description" />
+        </p>
+        <p>
+          <FormattedMessage id="savingsFund.payment.success.cancellationNotice" />
+        </p>
+
+        <a href="/account" className="btn btn-outline-primary">
+          <FormattedMessage id="savingsFund.payment.success.myAccountButton.label" />
+        </a>
+      </SuccessNotice2>
+    </div>
+  );
+};
+
+export default SavingsFundPaymentSuccess;

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1063,5 +1063,11 @@
   "savingsFund.payment.infoSection.investmentAccount.learnMore": "What is this and how does it work?",
   "savingsFund.payment.infoSection.creditor": "The money must come from a bank account in your name.",
   "savingsFund.payment.infoSection.fees": "No service fees.",
-  "savingsFund.payment.linkGenerationError": "There was an error initiating the payment. Please try again later or contact us: tuleva@tuleva.ee"
+  "savingsFund.payment.linkGenerationError": "There was an error initiating the payment. Please try again later or contact us: tuleva@tuleva.ee",
+
+  "savingsFund.payment.success.pageTitle": "Contribution made",
+  "savingsFund.payment.success.title": "Contribution made",
+  "savingsFund.payment.success.description": "The contribution amount will be invested in the fund by the end of tomorrow's business day. We will notify you of this by email.",
+  "savingsFund.payment.success.cancellationNotice": "The contribution can be cancelled today until 15:59.",
+  "savingsFund.payment.success.myAccountButton.label": "My Account"
 }

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1153,5 +1153,11 @@
   "savingsFund.payment.infoSection.investmentAccount.learnMore": "Mis see on ja kuidas see käib?",
   "savingsFund.payment.infoSection.creditor": "Raha peab laekuma sinu enda pangakontolt.",
   "savingsFund.payment.infoSection.fees": "Teenustasud puuduvad.",
-  "savingsFund.payment.linkGenerationError": "Makse algatamisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust: tuleva@tuleva.ee"
+  "savingsFund.payment.linkGenerationError": "Makse algatamisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust: tuleva@tuleva.ee",
+
+  "savingsFund.payment.success.pageTitle": "Sissemakse tehtud",
+  "savingsFund.payment.success.title": "Sissemakse on tehtud",
+  "savingsFund.payment.success.description": "Sissemakse summa investeeritakse fondi homse tööpäeva lõpuks. Teavitame sind sellest meili teel.",
+  "savingsFund.payment.success.cancellationNotice": "Sissemakset on võimalik tühistada täna kuni kell 15:59.",
+  "savingsFund.payment.success.myAccountButton.label": "Minu konto"
 }


### PR DESCRIPTION
Adds a static success page that'll be used for the Montonio successful payment callbacks.