### PR TITLE
Add Osakud column to transaction pages

### DIFF
--- a/src/components/account/TransactionSection/TransactionSection.test.tsx
+++ b/src/components/account/TransactionSection/TransactionSection.test.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { IntlProvider } from 'react-intl';
 import { TransactionSection } from './TransactionSection';
-import { contribution } from './fixtures';
+import { contribution, subtraction } from './fixtures';
 import { fundsBackend } from '../../../test/backend';
 import { initializeConfiguration } from '../../config/config';
 import { getAuthentication } from '../../common/authenticationManager';
@@ -103,6 +103,59 @@ describe('Transaction section', () => {
       server.on('request:end', () => setTimeout(resolve, 50));
     });
   }
+
+  it('shows Osakud column with unit values on full transaction page', async () => {
+    mockTransactions([contribution]);
+    initializeComponent({ pillar: 2 });
+    expect(await screen.findByText('transactions.columns.units.title')).toBeInTheDocument();
+    expect(screen.getAllByText('31.36')).toHaveLength(2);
+  });
+
+  it('shows unit total in footer when all transactions are from the same fund', async () => {
+    const secondContribution = {
+      ...contribution,
+      id: 'second-id',
+      time: '2023-02-15T10:00:00Z',
+      amount: 200,
+      units: 20.0,
+    };
+    mockTransactions([contribution, secondContribution]);
+    initializeComponent({ pillar: 2 });
+    expect(await screen.findByText('transactions.columns.units.title')).toBeInTheDocument();
+    expect(screen.getByText('51.36')).toBeInTheDocument();
+  });
+
+  it('does not show unit total when transactions are from different funds', async () => {
+    mockTransactions([contribution, subtraction]);
+    initializeComponent();
+    expect(await screen.findByText('transactions.columns.units.title')).toBeInTheDocument();
+    expect(screen.getByText('31.36')).toBeInTheDocument();
+    expect(screen.queryByText('41.36')).not.toBeInTheDocument();
+    expect(screen.queryByText('21.36')).not.toBeInTheDocument();
+  });
+
+  it('shows negative units for subtraction transactions', async () => {
+    mockTransactions([subtraction]);
+    initializeComponent({ pillar: 3 });
+    expect(await screen.findByText('transactions.columns.units.title')).toBeInTheDocument();
+    expect(screen.getAllByText('−10.00')).toHaveLength(2);
+  });
+
+  it('does not show Osakud column when limit is set', async () => {
+    mockTransactions([contribution]);
+    initializeComponent({ limit: 3 });
+    await waitForRequestToFinish();
+    expect(screen.queryByText('transactions.columns.units.title')).not.toBeInTheDocument();
+  });
+
+  it('makes date a link to transaction detail on full page', async () => {
+    mockTransactions([contribution]);
+    initializeComponent({ pillar: 2 });
+    expect(await screen.findByRole('link', { name: /23/ })).toHaveAttribute(
+      'href',
+      `/transaction/${contribution.id}`,
+    );
+  });
 
   function mockTransactions(transactions: any[]) {
     server.use(

--- a/src/components/account/TransactionSection/TransactionSection.tsx
+++ b/src/components/account/TransactionSection/TransactionSection.tsx
@@ -9,6 +9,7 @@ import Table from '../../common/table';
 import { Euro } from '../../common/Euro';
 import { Shimmer } from '../../common/shimmer/Shimmer';
 import { formatDate } from '../../common/dateFormatter';
+import { formatAmountForCount } from '../../common/utils';
 import { Breakpoint, TableColumn } from '../../common/table/Table';
 import { getOtherTransactionPages } from './getOtherTransactionPages';
 
@@ -67,6 +68,27 @@ export const TransactionSection: React.FunctionComponent<{
 
   const hasPensionTransactions = fundTransactions.some((transaction) => transaction.pillar);
 
+  const unitsColumn = (() => {
+    if (limit) {
+      return [];
+    }
+    const allSameFund =
+      fundTransactions.length > 0 && new Set(fundTransactions.map((t) => t.isin)).size === 1;
+    const unitsSum = sumBy(fundTransactions, (transaction) =>
+      transaction.type === 'SUBTRACTION' ? -(transaction.units ?? 0) : transaction.units ?? 0,
+    );
+    return [
+      {
+        title: <FormattedMessage id="transactions.columns.units.title" />,
+        dataIndex: 'units',
+        hideOnBreakpoint: ['xs', 'sm'] as Breakpoint[],
+        ...(allSameFund && {
+          footer: formatAmountForCount(unitsSum, 2),
+        }),
+      },
+    ];
+  })();
+
   const columns: TableColumn[] = [
     {
       title: <FormattedMessage id="transactions.columns.date.title" />,
@@ -90,6 +112,7 @@ export const TransactionSection: React.FunctionComponent<{
       width: 100,
       align: 'left',
     },
+    ...unitsColumn,
     {
       title: <FormattedMessage id="transactions.columns.amount.title" />,
       dataIndex: 'amount',
@@ -120,16 +143,25 @@ export const TransactionSection: React.FunctionComponent<{
             ) : (
               <FormattedMessage id="transactions.personal" />
             ),
-          date: <span className="text-nowrap">{date}</span>,
-          fund: <span>{transaction.fundName}</span>,
-          amount:
+          date:
             !limit && transaction.id ? (
-              <Link to={`/transaction/${transaction.id}`}>
-                <Euro amount={transaction.amount} />
+              <Link to={`/transaction/${transaction.id}`} className="text-nowrap">
+                {date}
               </Link>
             ) : (
-              <Euro amount={transaction.amount} />
+              <span className="text-nowrap">{date}</span>
             ),
+          fund: <span>{transaction.fundName}</span>,
+          ...(!limit &&
+            transaction.units != null && {
+              // Backend returns positive units for subtractions (unlike amounts which are negative).
+              // Negate here to match the amount sign convention. Remove if backend starts returning signed units.
+              units: formatAmountForCount(
+                transaction.type === 'SUBTRACTION' ? -transaction.units : transaction.units,
+                2,
+              ),
+            }),
+          amount: <Euro amount={transaction.amount} />,
           key: transaction.time,
         },
       ];

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -579,6 +579,7 @@
   "transactions.columns.date.title": "Date",
   "transactions.columns.date.footer": "Total",
   "transactions.columns.amount.title": "Amount",
+  "transactions.columns.units.title": "Units",
   "transactions.columns.entity.title": "Done by",
   "transactions.seeAll": "View all transactions",
   "transactions.seeAll.2": "II pillar",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -621,6 +621,7 @@
   "transactions.columns.date.footer": "Kokku",
   "transactions.columns.pillar.title": "Sammas",
   "transactions.columns.amount.title": "Summa",
+  "transactions.columns.units.title": "Osakud",
   "transactions.columns.entity.title": "Teostaja",
   "transactions.seeAll": "Vaatan kõiki tehinguid",
   "transactions.seeAll.2": "II sammas",


### PR DESCRIPTION
## Summary

Show per-transaction unit count on full transaction pages (II pillar, III pillar, TKF). Hidden on mobile and account page previews.

- Add "Osakud" column with units per transaction (2 decimal places)
- Show unit total in footer when all transactions are from the same fund
- Move clickable link from amount to date
- Negate units for SUBTRACTION type (backend returns positive units)

Closes TulevaEE/TKF-VPII2026#20

## Test plan

- [ ] Test in browser on desktop (II pillar, III pillar, TKF transaction pages)
- [ ] Test on mobile — Osakud column hidden
- [ ] Verify account page previews unchanged (PersonAccountPage, LegalEntityAccountPage)
- [ ] Verify Kokku units shown only for single-fund views
- [ ] Verify SUBTRACTION transactions show negative units

🤖 Generated with [Claude Code](https://claude.com/claude-code)