### PR TITLE
Add investment account reminder before payment confirmation

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -79,6 +79,46 @@ describe(SavingsFundPayment, () => {
     expect(submitButton).toBeEnabled();
   });
 
+  it('shows investment account reminder only after a bank is selected', async () => {
+    expect(await findPageHeading()).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Using an investment account? Check that the payer account is correct.'),
+    ).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
+
+    expect(
+      await screen.findByText(
+        'Using an investment account? Check that the payer account is correct.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show investment account reminder when "Other bank" is selected', async () => {
+    expect(await findPageHeading()).toBeInTheDocument();
+
+    const otherBankRadio = screen.getByRole('radio', { name: 'Other bank' });
+    userEvent.click(otherBankRadio);
+
+    expect(await screen.findByText('Did you make the payment?')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Using an investment account? Check that the payer account is correct.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show investment account reminder when amount is 15000 or more', async () => {
+    expect(await findPageHeading()).toBeInTheDocument();
+
+    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
+    userEvent.type(amountInput, '15000');
+
+    expect(await screen.findByText('Did you make the payment?')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Using an investment account? Check that the payer account is correct.'),
+    ).not.toBeInTheDocument();
+  });
+
   it('lets user select a bank and start the payment', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -178,18 +178,25 @@ export const SavingsFundPayment: FC = () => {
           )}
 
           {!showManualPayment && !isRecurring && (
-            <div className="d-flex justify-content-between border-top pt-4">
-              <Link to="/account" className="btn btn-outline-primary">
-                <FormattedMessage id="savingsFund.payment.form.cancel.label" />
-              </Link>
+            <div className="border-top pt-4 d-flex flex-column gap-3">
+              {paymentMethod ? (
+                <p className="text-body-secondary m-0">
+                  <FormattedMessage id="savingsFund.payment.investmentAccountReminder" />
+                </p>
+              ) : null}
+              <div className="d-flex justify-content-between">
+                <Link to="/account" className="btn btn-outline-primary">
+                  <FormattedMessage id="savingsFund.payment.form.cancel.label" />
+                </Link>
 
-              <button
-                type="submit"
-                className="btn btn-primary btn-loading"
-                disabled={!user.personalCode || isSubmitting}
-              >
-                <FormattedMessage id="savingsFund.payment.form.submit.label" />
-              </button>
+                <button
+                  type="submit"
+                  className="btn btn-primary btn-loading"
+                  disabled={!user.personalCode || isSubmitting}
+                >
+                  <FormattedMessage id="savingsFund.payment.form.submit.label" />
+                </button>
+              </div>
             </div>
           )}
         </section>

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1185,6 +1185,7 @@
   "savingsFund.payment.success.pageTitle": "Deposit made",
   "savingsFund.payment.success.title": "Deposit made",
   "savingsFund.payment.success.description": "The deposit amount will be invested in the fund by the end of next business day. We will notify you of this by email.",
+  "savingsFund.payment.investmentAccountReminder": "Using an investment account? Check that the payer account is correct.",
 
   "savingsFund.withdraw.pageTitle": "Withdraw",
   "savingsFund.withdraw.title": "Withdraw from additional savings fund",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1267,6 +1267,7 @@
   "savingsFund.payment.success.pageTitle": "Sissemakse tehtud",
   "savingsFund.payment.success.title": "Sissemakse on tehtud",
   "savingsFund.payment.success.description": "Sissemakse summa investeeritakse fondi järgneva tööpäeva lõpuks. Teavitame sind sellest meili teel.",
+  "savingsFund.payment.investmentAccountReminder": "Kasutad investeerimiskontot? Kontrolli, et maksja konto oleks õige.",
 
   "savingsFund.withdraw.pageTitle": "Väljamakse",
   "savingsFund.withdraw.title": "Väljamakse täiendavast kogumisfondist",


### PR DESCRIPTION
## Summary
Adds a one-line reminder above the Cancel/Continue buttons on `savings-fund/payment`, shown after a bank is selected:

> Kasutad investeerimiskontot? Kontrolli, et maksja konto oleks õige.

Addresses [TKF-VPII2026 issue #24](https://github.com/TulevaEE/TKF-VPII2026/issues/24) — users frequently pay from a non-investment account and have to cancel and redo the payment.

## Test plan
- [ ] Reminder appears after selecting a bank
- [ ] Reminder hidden when "Other bank" is selected (manual transfer flow)
- [ ] Reminder hidden when amount is 15 000+ EUR (manual transfer flow)
- [ ] Both Estonian and English translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)