### PR TITLE
fix: adapt legal entity onboarding investment goals and assets copy

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestableAssetsStep/InvestableAssetsStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestableAssetsStep/InvestableAssetsStep.test.tsx
@@ -45,7 +45,11 @@ const InvestableAssetsStepWrapper = () => {
   return (
     <IntlProvider locale="en" messages={translations.en}>
       <form>
-        <InvestableAssetsStep control={control} options={OPTIONS} />
+        <InvestableAssetsStep
+          control={control}
+          options={OPTIONS}
+          titleId="flows.savingsFundOnboarding.investableAssetsStep.title"
+        />
         <button type="button" onClick={() => trigger('investableAssets')}>
           Validate
         </button>
@@ -75,7 +79,11 @@ const CompanyInvestableAssetsStepWrapper = () => {
   return (
     <IntlProvider locale="en" messages={translations.en}>
       <form>
-        <InvestableAssetsStep control={control} options={OPTIONS} />
+        <InvestableAssetsStep
+          control={control}
+          options={OPTIONS}
+          titleId="flows.savingsFundOnboarding.investableAssetsStep.titleCompany"
+        />
         <button type="button" onClick={() => trigger('investableAssets')}>
           Validate
         </button>
@@ -135,8 +143,16 @@ describe('InvestableAssetsStep', () => {
     expect(screen.getByText(/80,001.*or more/)).toBeInTheDocument();
   });
 
-  test('works with CompanyOnboardingFormData', () => {
+  test('renders the company-flow title for CompanyOnboardingFormData', () => {
     renderWrapped(<CompanyInvestableAssetsStepWrapper />);
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+      'How much investable assets does your company have?',
+    );
+  });
+
+  test('renders the personal-flow title for OnboardingFormData', () => {
+    renderWrapped(<InvestableAssetsStepWrapper />);
 
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
       'How much investable assets do you have?',

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestableAssetsStep/InvestableAssetsStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestableAssetsStep/InvestableAssetsStep.tsx
@@ -8,6 +8,7 @@ import { Radio } from '../../../../common';
 type InvestableAssetsStepProps<T extends SharedOnboardingFields = SharedOnboardingFields> = {
   control: Control<T>;
   options: { value: InvestableAssetsOption; labelId: TranslationKey }[];
+  titleId: TranslationKey;
 };
 
 const optionRadioId = (value: InvestableAssetsOption) =>
@@ -40,13 +41,14 @@ const generateRadioOptions = (
 export const InvestableAssetsStep = <T extends SharedOnboardingFields = SharedOnboardingFields>({
   control,
   options,
+  titleId,
 }: InvestableAssetsStepProps<T>) => {
   const intl = useIntl();
   return (
     <section className="d-flex flex-column gap-4" key="investment-assets">
       <div className="d-flex flex-column gap-1">
         <h2 className="m-0">
-          <FormattedMessage id="flows.savingsFundOnboarding.investableAssetsStep.title" />
+          <FormattedMessage id={titleId} />
         </h2>
         <p className="m-0">
           <FormattedMessage id="flows.savingsFundOnboarding.investableAssetsStep.description" />

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestmentGoalStep/InvestmentGoalStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestmentGoalStep/InvestmentGoalStep.test.tsx
@@ -20,10 +20,13 @@ const PRIVATE_OPTIONS: StepOption[] = [
 ];
 
 const COMPANY_OPTIONS: StepOption[] = [
-  { value: 'LONG_TERM', labelId: 'flows.savingsFundOnboarding.investmentGoalStep.longTerm' },
+  {
+    value: 'LONG_TERM',
+    labelId: 'flows.savingsFundOnboarding.investmentGoalStep.longTermCompany',
+  },
   {
     value: 'SPECIFIC_GOAL',
-    labelId: 'flows.savingsFundOnboarding.investmentGoalStep.specificGoal',
+    labelId: 'flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany',
   },
   { value: 'TRADING', labelId: 'flows.savingsFundOnboarding.investmentGoalStep.activeTrading' },
 ];
@@ -49,29 +52,36 @@ const CompanyInvestmentGoalStepWrapper = ({ options }: { options: StepOption[] }
   return (
     <IntlProvider locale="en" messages={translations.en}>
       <form>
-        <InvestmentGoalStep control={control} options={options} />
+        <InvestmentGoalStep
+          control={control}
+          options={options}
+          titleId="flows.savingsFundOnboarding.investmentGoalStep.titleCompany"
+        />
       </form>
     </IntlProvider>
   );
 };
 
 describe('InvestmentGoalStep', () => {
-  it('works with CompanyOnboardingFormData', () => {
+  it('renders the company-flow title for CompanyOnboardingFormData', () => {
     renderWrapped(<CompanyInvestmentGoalStepWrapper options={COMPANY_OPTIONS} />);
 
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-      'What is your investment goal?',
+      "What is your company's investment goal?",
     );
   });
 
-  it('does not render CHILD option when excluded', () => {
+  it('renders company-specific labels and excludes CHILD', () => {
     renderWrapped(<CompanyInvestmentGoalStepWrapper options={COMPANY_OPTIONS} />);
 
-    expect(screen.getByText('Long-term investment, including pension')).toBeInTheDocument();
-    expect(screen.getByText('Specific goal (home, education, etc.)')).toBeInTheDocument();
+    expect(screen.getByText('Long-term growth of company assets')).toBeInTheDocument();
+    expect(
+      screen.getByText('Specific goal (e.g. equipment, property, expansion)'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Active trading, including daily trading')).toBeInTheDocument();
     expect(screen.getByText('Other…')).toBeInTheDocument();
     expect(screen.queryByText("Saving for child's future")).not.toBeInTheDocument();
+    expect(screen.queryByText('Long-term investment, including pension')).not.toBeInTheDocument();
   });
 
   it('renders all 4 options when private labels are passed', () => {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestmentGoalStep/InvestmentGoalStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestmentGoalStep/InvestmentGoalStep.tsx
@@ -9,6 +9,7 @@ import Radio from '../../../../common/radio';
 type InvestmentGoalStepProps<T extends SharedOnboardingFields = SharedOnboardingFields> = {
   control: Control<T>;
   options: { value: InvestmentGoalOption; labelId: TranslationKey }[];
+  titleId: TranslationKey;
 };
 
 const optionRadioId = (value: InvestmentGoalOption) =>
@@ -45,6 +46,7 @@ const generateRadioOptions = (
 export const InvestmentGoalStep = <T extends SharedOnboardingFields = SharedOnboardingFields>({
   control,
   options,
+  titleId,
 }: InvestmentGoalStepProps<T>) => {
   const intl = useIntl();
   const { field: investmentGoalsField } = useController({
@@ -69,7 +71,7 @@ export const InvestmentGoalStep = <T extends SharedOnboardingFields = SharedOnbo
     <section className="d-flex flex-column gap-4" key="investment-goal">
       <div className="d-flex flex-column gap-1">
         <h2 className="m-0">
-          <FormattedMessage id="flows.savingsFundOnboarding.investmentGoalStep.title" />
+          <FormattedMessage id={titleId} />
         </h2>
       </div>
       <div className="section-content d-flex flex-column gap-4">

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
@@ -226,7 +226,7 @@ const completeStepsThroughTerms = async () => {
   await advanceToStep(4);
 
   // Step 4: Investment Goal
-  userEvent.click(screen.getByRole('radio', { name: 'Long-term investment, including pension' }));
+  userEvent.click(screen.getByRole('radio', { name: 'Long-term growth of company assets' }));
   await advanceToStep(5);
 
   // Step 5: Investable Assets

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -76,14 +76,15 @@ export const SavingsFundCompanyOnboarding = () => {
         <InvestmentGoalStep
           key="investmentGoal"
           control={control}
+          titleId="flows.savingsFundOnboarding.investmentGoalStep.titleCompany"
           options={[
             {
               value: 'LONG_TERM',
-              labelId: 'flows.savingsFundOnboarding.investmentGoalStep.longTerm',
+              labelId: 'flows.savingsFundOnboarding.investmentGoalStep.longTermCompany',
             },
             {
               value: 'SPECIFIC_GOAL',
-              labelId: 'flows.savingsFundOnboarding.investmentGoalStep.specificGoal',
+              labelId: 'flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany',
             },
             {
               value: 'TRADING',
@@ -99,6 +100,7 @@ export const SavingsFundCompanyOnboarding = () => {
         <InvestableAssetsStep
           key="investableAssets"
           control={control}
+          titleId="flows.savingsFundOnboarding.investableAssetsStep.titleCompany"
           options={[
             {
               value: 'LESS_THAN_20K',

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
@@ -120,6 +120,7 @@ export const SavingsFundOnboarding: FC = () => {
         <InvestmentGoalStep
           key="investment-goal"
           control={control}
+          titleId="flows.savingsFundOnboarding.investmentGoalStep.title"
           options={[
             {
               value: 'LONG_TERM',
@@ -147,6 +148,7 @@ export const SavingsFundOnboarding: FC = () => {
         <InvestableAssetsStep
           key="investable-assets"
           control={control}
+          titleId="flows.savingsFundOnboarding.investableAssetsStep.title"
           options={[
             {
               value: 'LESS_THAN_20K',

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1292,6 +1292,9 @@
   "flows.savingsFundOnboarding.investmentGoalStep.otherPlaceholder": "Enter investment goal",
   "flows.savingsFundOnboarding.investmentGoalStep.required": "Select an option to continue.",
   "flows.savingsFundOnboarding.investmentGoalStep.other.required": "Enter your investment goal.",
+  "flows.savingsFundOnboarding.investmentGoalStep.longTermCompany": "Long-term growth of company assets",
+  "flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany": "Specific goal (e.g. equipment, property, expansion)",
+  "flows.savingsFundOnboarding.investmentGoalStep.titleCompany": "What is your company's investment goal?",
 
   "flows.savingsFundOnboarding.investableAssetsStep.title": "How much investable assets do you have?",
   "flows.savingsFundOnboarding.investableAssetsStep.description": "Investable assets are immediately available money and investments that you can sell quickly – for example, money in a bank account or deposit, and stocks, bonds, and funds.",
@@ -1300,6 +1303,7 @@
   "flows.savingsFundOnboarding.investableAssetsStep.from40kTo80k": "€40,001–€80,000",
   "flows.savingsFundOnboarding.investableAssetsStep.over80k": "€80,001 or more",
   "flows.savingsFundOnboarding.investableAssetsStep.required": "Select an option to continue.",
+  "flows.savingsFundOnboarding.investableAssetsStep.titleCompany": "How much investable assets does your company have?",
 
   "flows.savingsFundOnboarding.incomeSourcesStep.title": "What are your sources of income?",
   "flows.savingsFundOnboarding.incomeSourcesStep.description": "Select all sources from which you receive income.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1382,6 +1382,9 @@
   "flows.savingsFundOnboarding.investmentGoalStep.otherPlaceholder": "Sisesta investeerimise eesmärk",
   "flows.savingsFundOnboarding.investmentGoalStep.required": "Jätkamiseks tee valik.",
   "flows.savingsFundOnboarding.investmentGoalStep.other.required": "Sisesta investeerimise eesmärk.",
+  "flows.savingsFundOnboarding.investmentGoalStep.longTermCompany": "Osaühingu varade pikaajaline kasvatamine",
+  "flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany": "Konkreetne eesmärk (nt seadmed, kinnisvara, laienemine)",
+  "flows.savingsFundOnboarding.investmentGoalStep.titleCompany": "Mis on sinu osaühingu investeerimise eesmärk?",
 
   "flows.savingsFundOnboarding.investableAssetsStep.title": "Kui palju on sul investeeritavat vara?",
   "flows.savingsFundOnboarding.investableAssetsStep.description": "Investeeritavad varad on kohe kasutatav raha ja investeeringud, mida saad kiiresti müüa – näiteks pangakontol või hoiusel olev raha ning aktsiad, võlakirjad ja fondid.",
@@ -1390,6 +1393,7 @@
   "flows.savingsFundOnboarding.investableAssetsStep.from40kTo80k": "40 001–80 000 €",
   "flows.savingsFundOnboarding.investableAssetsStep.over80k": "80 001 € või enam",
   "flows.savingsFundOnboarding.investableAssetsStep.required": "Jätkamiseks tee valik.",
+  "flows.savingsFundOnboarding.investableAssetsStep.titleCompany": "Kui palju on sinu osaühingul investeeritavat vara?",
 
   "flows.savingsFundOnboarding.incomeSourcesStep.title": "Millised on sinu sissetulekuallikad?",
   "flows.savingsFundOnboarding.incomeSourcesStep.description": "Vali kõik allikad, kust sissetulekut saad.",


### PR DESCRIPTION
Related: TulevaEE/TKF-VPII2026#40

Splits two shared translation keys (`investableAssetsStep.title` and `investmentGoalStep.title`) and the investment-goal option labels so the legal entity flow can use OÜ-specific wording while the personal flow stays unchanged.

Builds on the prop-based override pattern introduced in 8488dbe0.

## Test plan

- [ ] Personal flow `/savings-fund/onboarding` — investment goal and investable assets steps unchanged
- [ ] Company flow `/savings-fund/company/onboarding` — investment goal title reads „Mis on sinu osaühingu investeerimise eesmärk?" with three OÜ-tailored options + Muu; investable assets title reads „Kui palju on sinu osaühingul investeeritavat vara?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)