### PR TITLE
TKF payment: adapt copy for legal entities

### DIFF
--- a/src/components/flows/savingsAccount/InfoSection/InfoSection.tsx
+++ b/src/components/flows/savingsAccount/InfoSection/InfoSection.tsx
@@ -1,44 +1,53 @@
 import { FC, ReactNode } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { SimpleList, SimpleListItem } from '../../../common/simpleList';
+import { RoleType } from '../../../common/apiModels';
 import { CircleOff, Defer, Deposit, Verify } from './assets';
 
 type InfoSectionVariant = 'payment' | 'withdraw';
 
 interface InfoSectionProps {
   variant: InfoSectionVariant;
+  roleType?: RoleType;
 }
 
-export const InfoSection: FC<InfoSectionProps> = ({ variant }) => {
+export const InfoSection: FC<InfoSectionProps> = ({ variant, roleType = 'PERSON' }) => {
   const intl = useIntl();
+  const isLegalEntity = roleType === 'LEGAL_ENTITY';
 
   return (
     <SimpleList>
       <SimpleListItem
-        title={intl.formatMessage({ id: `savingsFund.${variant}.infoSection.creditor` })}
+        title={
+          variant === 'payment' && isLegalEntity
+            ? intl.formatMessage({ id: 'savingsFund.payment.infoSection.creditor.legalEntity' })
+            : intl.formatMessage({ id: `savingsFund.${variant}.infoSection.creditor` })
+        }
         media={<Verify />}
       />
-      <SimpleListItem
-        title={
-          <>
-            <FormattedMessage
-              id={`savingsFund.${variant}.infoSection.investmentAccount`}
-              values={{ b: (chunks: ReactNode) => <strong>{chunks}</strong> }}
-            />
-            <br />
-            <a
-              href="https://tuleva.ee/soovitused/miks-kasutada-kogumisfondi-puhul-investeerimiskontot/"
-              target="_blank"
-              rel="noreferrer"
-            >
+      {!isLegalEntity && (
+        <SimpleListItem
+          title={
+            <>
               <FormattedMessage
-                id={`savingsFund.${variant}.infoSection.investmentAccount.learnMore`}
+                id={`savingsFund.${variant}.infoSection.investmentAccount`}
+                values={{ b: (chunks: ReactNode) => <strong>{chunks}</strong> }}
               />
-            </a>
-          </>
-        }
-        media={<Defer />}
-      />
+              <br />
+              <a
+                href="https://tuleva.ee/soovitused/miks-kasutada-kogumisfondi-puhul-investeerimiskontot/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                <FormattedMessage
+                  id={`savingsFund.${variant}.infoSection.investmentAccount.learnMore`}
+                />
+              </a>
+            </>
+          }
+          media={<Defer />}
+        />
+      )}
       <SimpleListItem
         title={intl.formatMessage({ id: `savingsFund.${variant}.infoSection.fees` })}
         media={variant === 'payment' ? <Deposit /> : <CircleOff />}

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -433,5 +433,41 @@ describe(SavingsFundPayment, () => {
       expect(await screen.findByText('Make a deposit from another bank')).toBeInTheDocument();
       expect(screen.getByText('12345678')).toBeInTheDocument();
     });
+
+    it('shows the company bank account creditor text instead of the personal one', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+
+      expect(
+        screen.getByText("The money must come from your company's bank account."),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('The money must come from a bank account in your name.'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the investment account info block', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+
+      expect(
+        screen.queryByText(/You can defer paying income tax on investment returns/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'What is this and how does it work?' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the investment account reminder after a bank is selected', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+
+      userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
+
+      await waitFor(() =>
+        expect(
+          screen.queryByText(
+            'Using an investment account? Check that the payer account is correct.',
+          ),
+        ).not.toBeInTheDocument(),
+      );
+    });
   });
 });

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -60,6 +60,8 @@ export const SavingsFundPayment: FC = () => {
     return null;
   }
 
+  const isLegalEntity = user.role.type === 'LEGAL_ENTITY';
+
   const handleRedirect = async (data: IPaymentForm) => {
     try {
       setSubmitError(false);
@@ -87,7 +89,7 @@ export const SavingsFundPayment: FC = () => {
       <PaymentTypeSelection paymentType={paymentType} setPaymentType={setPaymentType} />
 
       <div className="pt-4 pb-4 border-top border-bottom">
-        <InfoSection variant="payment" />
+        <InfoSection variant="payment" roleType={user.role.type} />
       </div>
 
       <form onSubmit={handleSubmit((data) => handleRedirect(data))} method="post">
@@ -179,7 +181,7 @@ export const SavingsFundPayment: FC = () => {
 
           {!showManualPayment && !isRecurring && (
             <div className="border-top pt-4 d-flex flex-column gap-3">
-              {paymentMethod ? (
+              {paymentMethod && !isLegalEntity ? (
                 <p className="text-body-secondary m-0">
                   <FormattedMessage id="savingsFund.payment.investmentAccountReminder" />
                 </p>

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1167,6 +1167,7 @@
   "savingsFund.payment.infoSection.investmentAccount": "You can defer paying income tax on investment returns if you declare your bank account as an <b>investment account</b>.",
   "savingsFund.payment.infoSection.investmentAccount.learnMore": "What is this and how does it work?",
   "savingsFund.payment.infoSection.creditor": "The money must come from a bank account in your name.",
+  "savingsFund.payment.infoSection.creditor.legalEntity": "The money must come from your company's bank account.",
   "savingsFund.payment.infoSection.fees": "Making a deposit is free.",
   "savingsFund.payment.linkGenerationError": "There was an error initiating the payment. Please try again later or contact us: tuleva@tuleva.ee.",
 

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1249,6 +1249,7 @@
   "savingsFund.payment.infoSection.investmentAccount": "Saad investeerimistulult tulumaksu tasumise edasi lükata, kui deklareerid oma pangakonto <b>investeerimiskontona</b>.",
   "savingsFund.payment.infoSection.investmentAccount.learnMore": "Mis see on ja kuidas see käib?",
   "savingsFund.payment.infoSection.creditor": "Raha peab laekuma sinu enda pangakontolt.",
+  "savingsFund.payment.infoSection.creditor.legalEntity": "Raha peab laekuma sinu osaühingu pangakontolt.",
   "savingsFund.payment.infoSection.fees": "Sissemakse tegemine on tasuta.",
   "savingsFund.payment.linkGenerationError": "Makse algatamisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust: tuleva@tuleva.ee",
 


### PR DESCRIPTION
## Summary

Adapts the TKF savings fund pages for legal entities.

**Sissemakse leht (`/savings-fund/payment`):**
- "Raha peab laekuma sinu osaühingu pangakontolt." asendab personaalse pangakonto teksti
- Investeerimiskonto tulumaksu-edasilükkamise plokk (ikoon + tekst + "Mis see on ja kuidas käib?" link) peidetud
- Pärast panga valikut investeerimiskonto meeldetuletust ei kuvata
- Püsimakse kontrolliaknas 3. samm: "Veendu, et maksad osaühingu pangakontolt..." asemel investeerimiskonto teksti

**Väljamakse leht (`/savings-fund/withdraw`):**
- "Raha saad kanda oma osaühingu pangakontole." asendab personaalse pangakonto teksti
- Investeerimiskonto plokk peidetud
- IBAN-i kirjeldus: "Väljamakseid saad teha osaühingu pangakontole, millelt oled varasemalt..."

Eraisikuvaade muutmata.

Püsimakse "Selgitus" reas on registrikood juba praegu õige — frontend annab `user.role.code` ja backend kasutab seda muutmata kujul, mis on osaühingu puhul registrikood.

Closes TulevaEE/TKF-VPII2026#7

## Test plan
- [x] Testid katavad legal-entity stsenaariumid (`SavingsFundPayment.spec`, `SavingsFundWithdraw.spec`)
- [x] Eraisikuvaate testid passivad endiselt
- [x] Lint puhas
- [x] Käsitsi kinnitatud kohalikus dev-keskkonnas reaalse OÜ profiiliga