### PR TITLE
2nd pillar flow: add popularity badge to equity fund card

### DIFF
--- a/src/components/flows/secondPillar/selectSources/targetFundSelector/TargetFundSelector.tsx
+++ b/src/components/flows/secondPillar/selectSources/targetFundSelector/TargetFundSelector.tsx
@@ -23,7 +23,15 @@ export const TargetFundSelector: React.FunctionComponent<Props> = ({
   return (
     <div className="row mx-0 mt-3 tv-target-fund__container align-items-stretch">
       {targetFunds.map((fund) => (
-        <div key={fund.isin} className="col-12 col-sm mb-2 me-2 p-0">
+        <div key={fund.isin} className="col-12 col-sm mb-2 me-2 p-0 position-relative">
+          {fund.isin === 'EE3600109435' && (
+            <span
+              className="badge rounded-pill text-bg-primary fw-medium position-absolute top-0 start-50 translate-middle"
+              style={{ zIndex: 1 }}
+            >
+              <FormattedMessage id="target.funds.EE3600109435.badge" />
+            </span>
+          )}
           <button
             type="button"
             className={`

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -112,6 +112,7 @@
   "capitalEvents.backToAccountPage": "Back to account page",
   "capitalEvents.title": "Your member capital transactions",
   "target.funds.EE3600109435.title": "Tuleva World Stocks Pension Fund",
+  "target.funds.EE3600109435.badge": "Chosen by 95% of Tuleva II pillar savers",
   "target.funds.EE3600109435.description": "A low-cost index fund that invests entirely in stocks. The annual returns of this fund can vary sharply. However, projected long-term returns are nevertheless significantly higher than for the bond fund.",
   "target.funds.EE3600109435.description.2": "Suitable for you if you want to achieve <b>the best long-term returns</b> and do not plan to withdraw your entire II pillar within the next 5 years.",
   "target.funds.EE3600109435.terms.link": "https://tuleva.ee/en/tuleva-world-stocks-pension-fund/",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -117,6 +117,7 @@
   "capitalEvents.title": "Sinu liikmekapitali tehingud",
 
   "target.funds.EE3600109435.title": "Tuleva Maailma Aktsiate Pensionifond",
+  "target.funds.EE3600109435.badge": "95% Tuleva II sambas kogujate valik",
   "target.funds.EE3600109435.description": "Madala tasuga indeksfond, mis investeerib täielikult aktsiatesse. Selle fondi tootlus võib järsult aastast-aastasse kõikuda. Oodatav tootlus on sellegipoolest oluliselt kõrgem kui võlakirjafondil.",
   "target.funds.EE3600109435.description.2": "Sobib sulle, kui soovid saavutada <b>parimat pikaajalist tootlust</b> ja ei plaani järgmise 5 aasta jooksul kogu II sammast välja võtta.",
   "target.funds.EE3600109435.terms.link": "https://tuleva.ee/tuleva-maailma-aktsiate-pensionifond/",


### PR DESCRIPTION
## Summary
- Adds a "95% Tuleva II sambas kogujate valik" pill badge above the Tuleva Maailma Aktsiate Pensionifond card in the 2nd pillar flow's "Choose fund" step.
- Badge appears only on the equity fund card (ISIN `EE3600109435`).
- Visual design mirrors the badge currently used on https://tuleva.ee/kuidas-tuua-pension-tulevasse/ (Bootstrap 5 `badge rounded-pill text-bg-primary`).

## Test plan
- [ ] Log into https://local.tuleva.ee:3000 and navigate the 2nd pillar flow to the "Choose fund" step.
- [ ] Verify the blue pill badge sits centered on the top border of the equity fund card.
- [ ] Verify the bond fund card has no badge.
- [ ] Switch language to English and verify EN translation reads "Chosen by 95% of Tuleva II pillar savers".
- [ ] `npm test -- --testPathPattern="(TargetFundSelector|SelectSources)"` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)