### PR TITLE
TKF payment: extend legal-entity copy to withdraw + recurring verify step

### DIFF
--- a/src/components/flows/savingsAccount/InfoSection/InfoSection.tsx
+++ b/src/components/flows/savingsAccount/InfoSection/InfoSection.tsx
@@ -11,6 +11,17 @@ interface InfoSectionProps {
   roleType?: RoleType;
 }
 
+const creditorMessageId = (variant: InfoSectionVariant, isLegalEntity: boolean) => {
+  if (!isLegalEntity) {
+    return variant === 'payment'
+      ? ('savingsFund.payment.infoSection.creditor' as const)
+      : ('savingsFund.withdraw.infoSection.creditor' as const);
+  }
+  return variant === 'payment'
+    ? ('savingsFund.payment.infoSection.creditor.legalEntity' as const)
+    : ('savingsFund.withdraw.infoSection.creditor.legalEntity' as const);
+};
+
 export const InfoSection: FC<InfoSectionProps> = ({ variant, roleType = 'PERSON' }) => {
   const intl = useIntl();
   const isLegalEntity = roleType === 'LEGAL_ENTITY';
@@ -18,11 +29,7 @@ export const InfoSection: FC<InfoSectionProps> = ({ variant, roleType = 'PERSON'
   return (
     <SimpleList>
       <SimpleListItem
-        title={
-          variant === 'payment' && isLegalEntity
-            ? intl.formatMessage({ id: 'savingsFund.payment.infoSection.creditor.legalEntity' })
-            : intl.formatMessage({ id: `savingsFund.${variant}.infoSection.creditor` })
-        }
+        title={intl.formatMessage({ id: creditorMessageId(variant, isLegalEntity) })}
         media={<Verify />}
       />
       {!isLegalEntity && (

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -469,5 +469,21 @@ describe(SavingsFundPayment, () => {
         ).not.toBeInTheDocument(),
       );
     });
+
+    it('shows company-bank verify step in the recurring panel instead of the investment-account one', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
+      userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
+
+      expect(
+        await screen.findByRole('heading', { name: 'Set up the recurring payment in LHV' }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/paying from the/i)).toBeInTheDocument();
+      expect(screen.getByText(/then confirm the standing order/i)).toBeInTheDocument();
+      expect(screen.queryByText(/paying from an/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/investment account/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -159,6 +159,7 @@ export const SavingsFundPayment: FC = () => {
               bank={recurringBank}
               amount={amount}
               personalCode={user.role.code}
+              isLegalEntity={isLegalEntity}
             />
           ) : null}
 

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
@@ -53,14 +53,14 @@ type Props = {
   bank: BankKey;
   amount: number | undefined;
   personalCode: string;
-  isLegalEntity?: boolean;
+  isLegalEntity: boolean;
 };
 
 export const SavingsFundRecurringDetails: FC<Props> = ({
   bank,
   amount,
   personalCode,
-  isLegalEntity = false,
+  isLegalEntity,
 }) => {
   const meta = BANK_META[bank];
   const hasAmount = Number.isFinite(amount) && (amount ?? 0) >= 1;

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
@@ -53,9 +53,15 @@ type Props = {
   bank: BankKey;
   amount: number | undefined;
   personalCode: string;
+  isLegalEntity?: boolean;
 };
 
-export const SavingsFundRecurringDetails: FC<Props> = ({ bank, amount, personalCode }) => {
+export const SavingsFundRecurringDetails: FC<Props> = ({
+  bank,
+  amount,
+  personalCode,
+  isLegalEntity = false,
+}) => {
   const meta = BANK_META[bank];
   const hasAmount = Number.isFinite(amount) && (amount ?? 0) >= 1;
   const { data, isLoading, isFetching, isError } = useQuery<PaymentLink>({
@@ -142,7 +148,11 @@ export const SavingsFundRecurringDetails: FC<Props> = ({ bank, amount, personalC
 
           <PaymentStep number={3}>
             <FormattedMessage
-              id="savingsFund.recurring.step.verify"
+              id={
+                isLegalEntity
+                  ? 'savingsFund.recurring.step.verify.legalEntity'
+                  : 'savingsFund.recurring.step.verify'
+              }
               values={{
                 b: (chunks: string) => <b>{chunks}</b>,
               }}

--- a/src/components/flows/savingsAccount/SavingsFundWithdraw/SavingsFundWithdraw.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundWithdraw/SavingsFundWithdraw.spec.tsx
@@ -2,13 +2,13 @@ import { Route } from 'react-router-dom';
 import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 import { createMemoryHistory, History } from 'history';
-import { screen, waitFor } from '@testing-library/react';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SavingsFundWithdraw } from './SavingsFundWithdraw';
 import { createDefaultStore, login, renderWrapped } from '../../../../test/utils';
 import LoggedInApp from '../../../LoggedInApp';
 import { initializeConfiguration } from '../../../config/config';
-import { useTestBackends } from '../../../../test/backend';
+import { useTestBackends, userBackend } from '../../../../test/backend';
 import { SourceFund } from '../../../common/apiModels';
 
 const mockSavingsFundBalance: SourceFund = {
@@ -283,5 +283,60 @@ describe(SavingsFundWithdraw, () => {
     await waitFor(() => expect(submittedData).toBeTruthy());
     expect(submittedData.amount).toBe(123.45);
     expect(history.location.pathname).toBe('/savings-fund/withdraw/success');
+  });
+
+  describe('when acting as a company', () => {
+    beforeEach(async () => {
+      cleanup();
+      userBackend(server, {
+        role: { type: 'LEGAL_ENTITY', code: '12345678', name: 'Test Company OÜ' },
+      });
+
+      initApp();
+      history.push('/savings-fund/withdraw');
+    });
+
+    it('hides the investment account info block in the withdraw view', async () => {
+      expect(
+        await screen.findByRole('heading', { name: 'Withdraw from Additional Savings Fund' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByText(/You can defer paying income tax on investment returns/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: 'What is this and how does it work?' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows company-bank creditor text instead of the personal one', async () => {
+      expect(
+        await screen.findByRole('heading', { name: 'Withdraw from Additional Savings Fund' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText('You can only withdraw to a bank account belonging to your company.'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('You can only withdraw to a bank account in your name.'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows company-bank IBAN description instead of the personal one', async () => {
+      expect(
+        await screen.findByRole('heading', { name: 'Withdraw from Additional Savings Fund' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText(
+          /You can only withdraw to a company bank account from which you have previously made a deposit to the Additional Savings Fund\./i,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          /You can only withdraw to your own bank account from which you have previously made a deposit/i,
+        ),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/flows/savingsAccount/SavingsFundWithdraw/SavingsFundWithdraw.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundWithdraw/SavingsFundWithdraw.tsx
@@ -5,7 +5,7 @@ import { Controller, useForm } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link, useHistory } from 'react-router-dom';
 import { createSavingsFundWithdrawal } from '../../../common/api';
-import { useSavingsFundBalance, useSavingsFundBankAccounts } from '../../../common/apiHooks';
+import { useMe, useSavingsFundBalance, useSavingsFundBankAccounts } from '../../../common/apiHooks';
 import { getBankName } from '../../../common/iban';
 import { usePageTitle } from '../../../common/usePageTitle';
 import { formatAmountForCurrency } from '../../../common/utils';
@@ -34,6 +34,7 @@ export const SavingsFundWithdraw: FC = () => {
   const [currentStep, setCurrentStep] = useState<'INPUT' | 'REVIEW'>('INPUT');
   const intl = useIntl();
   const history = useHistory();
+  const { data: user } = useMe();
   const { data: savingsFundBalance } = useSavingsFundBalance();
   const { data: bankAccounts } = useSavingsFundBankAccounts();
   const {
@@ -86,7 +87,7 @@ export const SavingsFundWithdraw: FC = () => {
 
       {currentStep === 'INPUT' ? (
         <div className="pt-4 pb-4 border-top border-bottom">
-          <InfoSection variant="withdraw" />
+          <InfoSection variant="withdraw" roleType={user?.role.type} />
         </div>
       ) : null}
 
@@ -176,7 +177,13 @@ export const SavingsFundWithdraw: FC = () => {
                 <div className="d-block invalid-feedback">{errors.iban.message}</div>
               ) : null}
               <p className="m-0 text-secondary">
-                <FormattedMessage id="savingsFund.withdraw.form.iban.description" />
+                <FormattedMessage
+                  id={
+                    user?.role.type === 'LEGAL_ENTITY'
+                      ? 'savingsFund.withdraw.form.iban.description.legalEntity'
+                      : 'savingsFund.withdraw.form.iban.description'
+                  }
+                />
               </p>
             </div>
 

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1196,6 +1196,7 @@
   "savingsFund.withdraw.form.amount.description": "The withdrawal will be processed within three business days. The exact amount will be determined by the sale of units and depends on the market price of the units.",
   "savingsFund.withdraw.form.iban.label": "Bank account",
   "savingsFund.withdraw.form.iban.description": "You can only withdraw to your own bank account from which you have previously made a deposit to the Additional Savings Fund.",
+  "savingsFund.withdraw.form.iban.description.legalEntity": "You can only withdraw to a company bank account from which you have previously made a deposit to the Additional Savings Fund.",
   "savingsFund.withdraw.form.iban.placeholder": "Select bank account",
   "savingsFund.withdraw.form.iban.required": "Please select a bank account",
   "savingsFund.withdraw.form.continue.label": "Continue",
@@ -1206,6 +1207,7 @@
   "savingsFund.withdraw.infoSection.investmentAccount": "You can defer paying income tax on investment returns if you declare your bank account as an <b>investment account</b>.",
   "savingsFund.withdraw.infoSection.investmentAccount.learnMore": "What is this and how does it work?",
   "savingsFund.withdraw.infoSection.creditor": "You can only withdraw to a bank account in your name.",
+  "savingsFund.withdraw.infoSection.creditor.legalEntity": "You can only withdraw to a bank account belonging to your company.",
   "savingsFund.withdraw.infoSection.fees": "Making a withdrawal is free.",
   "savingsFund.withdraw.error": "There was an error processing your withdrawal request. Please try again later or contact us: tuleva@tuleva.ee",
 
@@ -1238,6 +1240,7 @@
   "savingsFund.recurring.step.copyFields": "Copy these details into your bank",
   "savingsFund.recurring.step.review": "Check the details",
   "savingsFund.recurring.step.verify": "Make sure you're paying from an <b>investment account</b>, then confirm the standing order",
+  "savingsFund.recurring.step.verify.legalEntity": "Make sure you're paying from the <b>company's bank account</b>, then confirm the standing order",
   "savingsFund.recurring.copyCard.recipientName": "Recipient name",
   "savingsFund.recurring.copyCard.recipientIban": "Recipient account (IBAN)",
   "savingsFund.recurring.copyCard.description": "Description",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1278,6 +1278,7 @@
   "savingsFund.withdraw.form.amount.description": "Väljamakse laekub kolme tööpäeva jooksul. Täpne summa selgub osakute müümisel ja sõltub osakute turuhinnast.",
   "savingsFund.withdraw.form.iban.label": "Pangakonto",
   "savingsFund.withdraw.form.iban.description": "Väljamakseid saad teha iseenda pangakontole, millelt oled varasemalt Täiendavasse Kogumisfondi sissemakse teinud.",
+  "savingsFund.withdraw.form.iban.description.legalEntity": "Väljamakseid saad teha osaühingu pangakontole, millelt oled varasemalt Täiendavasse Kogumisfondi sissemakse teinud.",
   "savingsFund.withdraw.form.iban.placeholder": "Vali pangakonto",
   "savingsFund.withdraw.form.iban.required": "Vali, millesele pangakontole soovid väljamakse teha",
   "savingsFund.withdraw.form.continue.label": "Jätkan",
@@ -1288,6 +1289,7 @@
   "savingsFund.withdraw.infoSection.investmentAccount": "Saad investeerimistulult tulumaksu tasumise edasi lükata, kui deklareerid oma pangakonto <b>investeerimiskontona</b>.",
   "savingsFund.withdraw.infoSection.investmentAccount.learnMore": "Mis see on ja kuidas see käib?",
   "savingsFund.withdraw.infoSection.creditor": "Raha saad kanda oma enda pangakontole.",
+  "savingsFund.withdraw.infoSection.creditor.legalEntity": "Raha saad kanda oma osaühingu pangakontole.",
   "savingsFund.withdraw.infoSection.fees": "Väljamakse tegemine on tasuta.",
   "savingsFund.withdraw.error": "Väljamakse algatamisel tekkis viga. Palun proovi hiljem uuesti või võta meiega ühendust: tuleva@tuleva.ee",
 
@@ -1328,6 +1330,7 @@
   "savingsFund.recurring.step.copyFields": "Kopeeri andmed panka",
   "savingsFund.recurring.step.review": "Kontrolli andmed üle",
   "savingsFund.recurring.step.verify": "Veendu, et maksad <b>investeerimiskontolt</b>, ja kinnita püsimakse",
+  "savingsFund.recurring.step.verify.legalEntity": "Veendu, et maksad <b>osaühingu pangakontolt</b>, ja kinnita püsimakse",
   "savingsFund.recurring.copyCard.recipientName": "Saaja nimi",
   "savingsFund.recurring.copyCard.recipientIban": "Kontonumber",
   "savingsFund.recurring.copyCard.description": "Selgitus",


### PR DESCRIPTION
Follow-up to #1551 (which Vootele has already approved). Splits these two new commits out so they can be reviewed independently rather than landing under the prior approval.

## Summary

**Püsimakse verify-aken** (`SavingsFundRecurringDetails`): 3. samm näitas osaühingule samuti "Veendu, et maksad investeerimiskontolt…". Asendub osaühingu vaates "Veendu, et maksad osaühingu pangakontolt…".

**Väljamakse leht** (`/savings-fund/withdraw`): rakendab sama OÜ-loogika nagu sissemaksete lehel — kreeditori tekst, investeerimiskonto plokk peidetud, IBAN-i kirjeldus osaühingu-spetsiifiline.

Closes TulevaEE/TKF-VPII2026#7 (koos #1551-ga).

## Test plan
- [x] Testid katavad uued stsenaariumid `SavingsFundPayment.spec` ja `SavingsFundWithdraw.spec`
- [x] Lint puhas
- [x] Käsitsi kinnitatud lokaalselt reaalse OÜ profiiliga