### PR TITLE
Add drift check for savings-fund onboarding documents

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -10,6 +10,7 @@ import { InvestmentGoalStep } from './InvestmentGoalStep';
 import { InvestableAssetsStep } from './InvestableAssetsStep';
 import { CompanyIncomeSourceStep } from './CompanyIncomeSourceStep';
 import { TermsStep } from './TermsStep';
+import { SAVINGS_FUND_DOCUMENTS } from './savingsFundDocuments';
 import { OnboardingWizardLayout } from './OnboardingWizardLayout';
 import {
   useSavingsFundCompanyOnboardingStatus,
@@ -128,26 +129,7 @@ export const SavingsFundCompanyOnboarding = () => {
       fields: ['sourceOfCompanyIncome'],
     },
     {
-      component: (
-        <TermsStep
-          key="terms"
-          control={control}
-          documents={[
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
-            },
-          ]}
-        />
-      ),
+      component: <TermsStep key="terms" control={control} documents={SAVINGS_FUND_DOCUMENTS} />,
       fields: ['termsAccepted'],
     },
   ];

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
@@ -12,6 +12,7 @@ import { InvestmentGoalStep } from './InvestmentGoalStep';
 import { InvestableAssetsStep } from './InvestableAssetsStep';
 import { IncomeSourcesStep } from './IncomeSourcesStep';
 import { TermsStep } from './TermsStep';
+import { SAVINGS_FUND_DOCUMENTS } from './savingsFundDocuments';
 import { OnboardingFormData } from './types';
 import {
   useMe,
@@ -176,26 +177,7 @@ export const SavingsFundOnboarding: FC = () => {
       fields: ['sourceOfIncome'],
     },
     {
-      component: (
-        <TermsStep
-          key="terms"
-          control={control}
-          documents={[
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
-            },
-          ]}
-        />
-      ),
+      component: <TermsStep key="terms" control={control} documents={SAVINGS_FUND_DOCUMENTS} />,
       fields: ['termsAccepted'],
     },
   ];

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.test.tsx
@@ -4,23 +4,9 @@ import { useForm } from 'react-hook-form';
 import { IntlProvider } from 'react-intl';
 import { renderWrapped } from '../../../../../test/utils';
 import { TermsStep } from './TermsStep';
+import { SAVINGS_FUND_DOCUMENTS } from '../savingsFundDocuments';
 import { OnboardingFormData, CompanyOnboardingFormData } from '../types';
-import translations, { TranslationKey } from '../../../../translations';
-
-const DOCUMENTS: { href: string; labelId: TranslationKey }[] = [
-  {
-    href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
-    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
-  },
-  {
-    href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
-    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
-  },
-  {
-    href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
-    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
-  },
-];
+import translations from '../../../../translations';
 
 const TermsStepWrapper = ({ showError = false }: { showError?: boolean }) => {
   const { control, trigger } = useForm<OnboardingFormData>({
@@ -46,7 +32,7 @@ const TermsStepWrapper = ({ showError = false }: { showError?: boolean }) => {
   return (
     <IntlProvider locale="en" messages={translations.en}>
       <form>
-        <TermsStep control={control} documents={DOCUMENTS} showError={showError} />
+        <TermsStep control={control} documents={SAVINGS_FUND_DOCUMENTS} showError={showError} />
         <button type="button" onClick={() => trigger('termsAccepted')}>
           Validate
         </button>
@@ -76,7 +62,7 @@ const CompanyTermsStepWrapper = () => {
   return (
     <IntlProvider locale="en" messages={translations.en}>
       <form>
-        <TermsStep control={control} documents={DOCUMENTS} />
+        <TermsStep control={control} documents={SAVINGS_FUND_DOCUMENTS} />
         <button type="button" onClick={() => trigger('termsAccepted')}>
           Validate
         </button>

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocuments.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocuments.ts
@@ -1,0 +1,16 @@
+import { TranslationKey } from '../../../translations';
+
+export const SAVINGS_FUND_DOCUMENTS: { href: string; labelId: TranslationKey }[] = [
+  {
+    href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
+    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
+  },
+  {
+    href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
+    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
+  },
+  {
+    href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
+    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
+  },
+];

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocumentsCheck.live.test.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocumentsCheck.live.test.ts
@@ -1,0 +1,11 @@
+import { fetchPublishedDocuments, shippedDocuments } from './savingsFundDocumentsCheck';
+
+const liveCheckEnabled = process.env.CHECK_PUBLISHED_DOCUMENTS === 'true';
+
+(liveCheckEnabled ? describe : describe.skip)('savings fund documents (live)', () => {
+  test('onboarding links to the documents currently published on tuleva.ee', async () => {
+    const published = await fetchPublishedDocuments();
+
+    expect(shippedDocuments()).toEqual(published);
+  }, 30000);
+});

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocumentsCheck.test.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocumentsCheck.test.ts
@@ -1,0 +1,50 @@
+import { publishedDocumentsFromAcf, shippedDocuments } from './savingsFundDocumentsCheck';
+
+describe('publishedDocumentsFromAcf', () => {
+  test('reads the document URLs from the savings fund page ACF fields', () => {
+    const acf = {
+      terms_file:
+        'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+      prospectus_file:
+        'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
+      key_investor_info_file:
+        'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
+      model_portfolio_file: 'https://tuleva.ee/wp-content/uploads/2026/03/Mudelportfell.pdf',
+    };
+
+    expect(publishedDocumentsFromAcf(acf)).toEqual({
+      terms:
+        'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+      prospectus:
+        'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
+      keyInformation:
+        'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
+    });
+  });
+
+  test('fails closed when a document field is missing or empty', () => {
+    const acf = {
+      terms_file: 'https://tuleva.ee/wp-content/uploads/2026/02/terms.pdf',
+      prospectus_file: '',
+    };
+
+    expect(() => publishedDocumentsFromAcf(acf)).toThrow(/prospectus_file/);
+  });
+
+  test('fails closed when there is no ACF data at all', () => {
+    expect(() => publishedDocumentsFromAcf(undefined)).toThrow(/terms_file/);
+  });
+});
+
+describe('shippedDocuments', () => {
+  test('maps the onboarding document constant to a URL per document type', () => {
+    expect(shippedDocuments()).toEqual({
+      terms:
+        'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
+      prospectus:
+        'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
+      keyInformation:
+        'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
+    });
+  });
+});

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocumentsCheck.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/savingsFundDocumentsCheck.ts
@@ -1,0 +1,77 @@
+import { SAVINGS_FUND_DOCUMENTS } from './savingsFundDocuments';
+
+export type SavingsFundDocumentType = 'terms' | 'prospectus' | 'keyInformation';
+
+export type SavingsFundDocumentUrls = Record<SavingsFundDocumentType, string>;
+
+const ACF_FIELD: Record<SavingsFundDocumentType, string> = {
+  terms: 'terms_file',
+  prospectus: 'prospectus_file',
+  keyInformation: 'key_investor_info_file',
+};
+
+const TYPE_BY_LABEL: Record<string, SavingsFundDocumentType> = {
+  'flows.savingsFundOnboarding.termsStep.linkText.terms': 'terms',
+  'flows.savingsFundOnboarding.termsStep.linkText.prospectus': 'prospectus',
+  'flows.savingsFundOnboarding.termsStep.linkText.keyInfo': 'keyInformation',
+};
+
+const DOCUMENT_TYPES: SavingsFundDocumentType[] = ['terms', 'prospectus', 'keyInformation'];
+
+const DOCUMENTS_PAGE_ACF_URL =
+  'https://tuleva.ee/wp-json/wp/v2/pages?slug=tuleva-taiendav-kogumisfond-dokumendid';
+
+export const normalizeDocumentUrl = (url: string): string => {
+  const parsed = new URL(url);
+  return `${parsed.protocol}//${parsed.hostname.toLowerCase()}${parsed.pathname}`;
+};
+
+export const publishedDocumentsFromAcf = (
+  acf: Record<string, unknown> | undefined,
+): SavingsFundDocumentUrls => {
+  const resolved: Partial<SavingsFundDocumentUrls> = {};
+  const missing: string[] = [];
+
+  DOCUMENT_TYPES.forEach((type) => {
+    const field = ACF_FIELD[type];
+    const value = acf ? acf[field] : undefined;
+    if (typeof value === 'string' && value.length > 0) {
+      resolved[type] = normalizeDocumentUrl(value);
+    } else {
+      missing.push(field);
+    }
+  });
+
+  if (missing.length > 0) {
+    throw new Error(`Savings fund document ACF fields missing or empty: [${missing.join(', ')}]`);
+  }
+
+  return resolved as SavingsFundDocumentUrls;
+};
+
+export const shippedDocuments = (): SavingsFundDocumentUrls => {
+  const resolved: Partial<SavingsFundDocumentUrls> = {};
+
+  SAVINGS_FUND_DOCUMENTS.forEach(({ href, labelId }) => {
+    const type = TYPE_BY_LABEL[labelId];
+    if (type) {
+      resolved[type] = normalizeDocumentUrl(href);
+    }
+  });
+
+  return resolved as SavingsFundDocumentUrls;
+};
+
+export const fetchPublishedDocuments = async (): Promise<SavingsFundDocumentUrls> => {
+  const response = await fetch(DOCUMENTS_PAGE_ACF_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch savings fund documents page: HTTP ${response.status}`);
+  }
+
+  const pages = (await response.json()) as { acf?: Record<string, unknown> }[];
+  if (!pages[0]) {
+    throw new Error('Savings fund documents page not found');
+  }
+
+  return publishedDocumentsFromAcf(pages[0].acf);
+};


### PR DESCRIPTION
## What

The Täiendav Kogumisfond onboarding signing step links to the fund's legal documents (terms, prospectus, key information). Those URLs were **hardcoded and duplicated** across both the individual and company onboarding flows, so they silently go stale whenever the documents are re-issued (they currently point at the `12.01.2026` versions, which have since been superseded).

This PR:
- Consolidates the three duplicated document arrays into a single `SAVINGS_FUND_DOCUMENTS` constant (used by both flows and the test).
- Adds a check (`savingsFundDocumentsCheck.ts`) that compares the shipped URLs against the documents **currently published** on the public fund page, read straight from its ACF fields (`terms_file` / `prospectus_file` / `key_investor_info_file`). `publishedDocumentsFromAcf` fails closed if a field is missing or empty.
- Adds a **gated** live comparison test (`savingsFundDocumentsCheck.live.test.ts`) that runs only when `CHECK_PUBLISHED_DOCUMENTS=true`, so it can run on a schedule without flaking normal CI.

## Note

The shipped URLs are **intentionally still the stale versions** in this PR — this lands the safety net first. They're brought current via the content-update workflow (separate step), which turns the live check green.

## Depends on

- TulevaEE/wordpress-theme#67 — enables `show_in_rest` on the documents ACF group so the live check can read those fields over REST.

## Test plan

- `savingsFundDocumentsCheck.test.ts` unit tests (extraction, fail-closed, shipped mapping) — green.
- Full suite green in CI (`build` / `test`).
- Live check runs on demand: `CHECK_PUBLISHED_DOCUMENTS=true TZ=UTC npx react-scripts test --testPathPattern=savingsFundDocumentsCheck.live` (meaningful once the wordpress-theme change is deployed).

Refs TulevaEE/TKF-VPII2026#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)
