### PR TITLE
Read TKF onboarding document links from the backend API

### DIFF
--- a/src/components/common/api.ts
+++ b/src/components/common/api.ts
@@ -27,6 +27,7 @@ import {
   PaymentLink,
   PaymentType,
   Role,
+  SavingsFundDocuments,
   SavingsFundOnboardingStatus,
   SecondPillarAssets,
   SigningMethod,
@@ -247,6 +248,10 @@ export function getFundPensionStatus(): Promise<FundPensionStatus> {
 
 export function getSavingsFundOnboardingStatus(): Promise<SavingsFundOnboardingStatus> {
   return getWithAuthentication(getEndpoint('/v1/savings/onboarding/status'));
+}
+
+export function getSavingsFundDocuments(): Promise<SavingsFundDocuments> {
+  return getWithAuthentication(getEndpoint('/v1/savings/documents'));
 }
 
 export function postSavingsFundOnboardingSurvey(command: OnboardingSurveyCommand): Promise<void> {

--- a/src/components/common/apiHooks.ts
+++ b/src/components/common/apiHooks.ts
@@ -31,6 +31,7 @@ import {
   getSavingsFundBalance,
   getSavingsFundBankAccounts,
   getSavingsFundCompanyOnboardingStatus,
+  getSavingsFundDocuments,
   getSavingsFundOnboardingStatus,
   getSecondPillarAssets,
   getSourceFunds,
@@ -63,6 +64,7 @@ import {
   SecondPillarAssets,
   SwitchRoleCommand,
   Token,
+  SavingsFundDocuments,
   SavingsFundOnboardingStatus,
   SavingsFundPaymentCancellationCommand,
   SourceFund,
@@ -203,6 +205,13 @@ export function useSavingsFundOnboardingStatus(): UseQueryResult<SavingsFundOnbo
   return useQuery({
     queryKey: ['savingsFundOnboardingStatus'],
     queryFn: () => getSavingsFundOnboardingStatus(),
+  });
+}
+
+export function useSavingsFundDocuments(): UseQueryResult<SavingsFundDocuments> {
+  return useQuery({
+    queryKey: ['savingsFundDocuments'],
+    queryFn: () => getSavingsFundDocuments(),
   });
 }
 

--- a/src/components/common/apiModels/index.ts
+++ b/src/components/common/apiModels/index.ts
@@ -183,6 +183,12 @@ export type SavingsFundOnboardingStatus = {
   status: null | 'COMPLETED' | 'REJECTED' | 'PENDING';
 };
 
+export type SavingsFundDocuments = {
+  terms: string;
+  prospectus: string;
+  keyInformation: string;
+};
+
 export type FundStatus =
   | 'ACTIVE'
   | 'LIQUIDATED'

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
@@ -3,7 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { businessRegistryBackend, companyValidationBackend } from '../../../../test/backend';
+import {
+  businessRegistryBackend,
+  companyValidationBackend,
+  savingsFundDocumentsBackend,
+} from '../../../../test/backend';
 import { mockValidatedCompany } from '../../../../test/backend-responses';
 import { initializeConfiguration } from '../../../config/config';
 import { renderWrapped } from '../../../../test/utils';
@@ -16,6 +20,7 @@ beforeEach(() => {
   initializeConfiguration();
   businessRegistryBackend(server, [{ company_id: 123, name: 'Acme Corp', reg_code: '12345678' }]);
   companyValidationBackend(server);
+  savingsFundDocumentsBackend(server);
 });
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -13,6 +13,7 @@ import { TermsStep } from './TermsStep';
 import { OnboardingWizardLayout } from './OnboardingWizardLayout';
 import {
   useSavingsFundCompanyOnboardingStatus,
+  useSavingsFundDocuments,
   useSubmitSavingsFundCompanyOnboardingSurvey,
 } from '../../../common/apiHooks';
 import { transformCompanyFormDataToSurveyCommand } from '../utils';
@@ -24,6 +25,7 @@ export const SavingsFundCompanyOnboarding = () => {
   const [submittedRegistryCode, setSubmittedRegistryCode] = useState<string | undefined>(undefined);
 
   const { data: onboardingStatus } = useSavingsFundCompanyOnboardingStatus(submittedRegistryCode);
+  const { data: fundDocuments } = useSavingsFundDocuments();
   const { mutateAsync: submitSurvey, isPending: submittingSurvey } =
     useSubmitSavingsFundCompanyOnboardingSurvey();
 
@@ -132,20 +134,24 @@ export const SavingsFundCompanyOnboarding = () => {
         <TermsStep
           key="terms"
           control={control}
-          documents={[
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
-            },
-          ]}
+          documents={
+            fundDocuments
+              ? [
+                  {
+                    href: fundDocuments.terms,
+                    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
+                  },
+                  {
+                    href: fundDocuments.prospectus,
+                    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
+                  },
+                  {
+                    href: fundDocuments.keyInformation,
+                    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
+                  },
+                ]
+              : []
+          }
         />
       ),
       fields: ['termsAccepted'],

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
@@ -185,6 +185,13 @@ describe('SavingsFundOnboarding', () => {
     expect(
       await screen.findByRole('heading', { name: 'Review fund documents', level: 2 }),
     ).toBeInTheDocument();
+
+    // Document links come from the backend (GET /v1/savings/documents), not a hardcoded constant
+    expect(await screen.findByRole('link', { name: /Terms/i })).toHaveAttribute(
+      'href',
+      'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+    );
+
     const termsCheckbox = screen.getByLabelText(
       'I confirm that I have reviewed the documents and understand that the investment may increase or decrease in value over time',
     );

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
@@ -15,6 +15,7 @@ import { TermsStep } from './TermsStep';
 import { OnboardingFormData } from './types';
 import {
   useMe,
+  useSavingsFundDocuments,
   useSavingsFundOnboardingStatus,
   useSubmitSavingsFundOnboardingSurvey,
 } from '../../../common/apiHooks';
@@ -40,6 +41,7 @@ export const SavingsFundOnboarding: FC = () => {
     refetch: refetchOnboardingStatus,
   } = useSavingsFundOnboardingStatus();
   const { data: user } = useMe();
+  const { data: fundDocuments } = useSavingsFundDocuments();
 
   const { control, setValue, watch, handleSubmit, trigger } = useForm<OnboardingFormData>({
     mode: 'onChange',
@@ -180,20 +182,24 @@ export const SavingsFundOnboarding: FC = () => {
         <TermsStep
           key="terms"
           control={control}
-          documents={[
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
-            },
-            {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
-              labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
-            },
-          ]}
+          documents={
+            fundDocuments
+              ? [
+                  {
+                    href: fundDocuments.terms,
+                    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
+                  },
+                  {
+                    href: fundDocuments.prospectus,
+                    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
+                  },
+                  {
+                    href: fundDocuments.keyInformation,
+                    labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
+                  },
+                ]
+              : []
+          }
         />
       ),
       fields: ['termsAccepted'],

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.test.tsx
@@ -22,7 +22,13 @@ const DOCUMENTS: { href: string; labelId: TranslationKey }[] = [
   },
 ];
 
-const TermsStepWrapper = ({ showError = false }: { showError?: boolean }) => {
+const TermsStepWrapper = ({
+  showError = false,
+  documents = DOCUMENTS,
+}: {
+  showError?: boolean;
+  documents?: { href: string; labelId: TranslationKey }[];
+}) => {
   const { control, trigger } = useForm<OnboardingFormData>({
     mode: 'onBlur',
     defaultValues: {
@@ -46,7 +52,7 @@ const TermsStepWrapper = ({ showError = false }: { showError?: boolean }) => {
   return (
     <IntlProvider locale="en" messages={translations.en}>
       <form>
-        <TermsStep control={control} documents={DOCUMENTS} showError={showError} />
+        <TermsStep control={control} documents={documents} showError={showError} />
         <button type="button" onClick={() => trigger('termsAccepted')}>
           Validate
         </button>
@@ -113,6 +119,13 @@ describe('TermsStep', () => {
       'href',
       'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
     );
+  });
+
+  test('shows a loading state and no document links while documents are loading', () => {
+    renderWrapped(<TermsStepWrapper documents={[]} />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   test('renders the terms checkbox', () => {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.tsx
@@ -3,6 +3,7 @@ import { Control, Controller, Path } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { SharedOnboardingFields } from '../types';
 import { TranslationKey } from '../../../../translations';
+import { Loader } from '../../../../common/loader/Loader';
 
 type TermsStepProps<T extends SharedOnboardingFields = SharedOnboardingFields> = {
   control: Control<T>;
@@ -23,48 +24,52 @@ export const TermsStep = <T extends SharedOnboardingFields = SharedOnboardingFie
           <FormattedMessage id="flows.savingsFundOnboarding.termsStep.title" />
         </h2>
       </div>
-      <div className="section-content d-flex flex-column gap-5">
-        <div className="d-flex flex-column gap-3">
-          {documents.map(({ href, labelId }) => (
-            <DocumentLink key={href} href={href}>
-              <FormattedMessage id={labelId} />
-            </DocumentLink>
-          ))}
+      {documents.length === 0 ? (
+        <Loader className="align-self-center" />
+      ) : (
+        <div className="section-content d-flex flex-column gap-5">
+          <div className="d-flex flex-column gap-3">
+            {documents.map(({ href, labelId }) => (
+              <DocumentLink key={href} href={href}>
+                <FormattedMessage id={labelId} />
+              </DocumentLink>
+            ))}
+          </div>
+          <Controller
+            control={control}
+            name={'termsAccepted' as Path<T>}
+            rules={{
+              validate: (value) =>
+                value === true ||
+                intl.formatMessage({ id: 'flows.savingsFundOnboarding.termsStep.error' }),
+            }}
+            render={({ field, fieldState: { error } }) => (
+              <div className="form-check m-0 lead">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  id="terms-accepted"
+                  checked={field.value as boolean}
+                  onChange={field.onChange}
+                />
+                <label className="form-check-label w-100" htmlFor="terms-accepted">
+                  <FormattedMessage id="flows.savingsFundOnboarding.termsStep.confirmText" />
+                </label>
+                {showError && (
+                  <p className="m-0 text-danger fs-base" role="alert">
+                    <FormattedMessage id="flows.savingsFundOnboarding.termsStep.error" />
+                  </p>
+                )}
+                {error && error.message ? (
+                  <p className="m-0 text-danger fs-base" role="alert">
+                    {error.message}
+                  </p>
+                ) : null}
+              </div>
+            )}
+          />
         </div>
-        <Controller
-          control={control}
-          name={'termsAccepted' as Path<T>}
-          rules={{
-            validate: (value) =>
-              value === true ||
-              intl.formatMessage({ id: 'flows.savingsFundOnboarding.termsStep.error' }),
-          }}
-          render={({ field, fieldState: { error } }) => (
-            <div className="form-check m-0 lead">
-              <input
-                className="form-check-input"
-                type="checkbox"
-                id="terms-accepted"
-                checked={field.value as boolean}
-                onChange={field.onChange}
-              />
-              <label className="form-check-label w-100" htmlFor="terms-accepted">
-                <FormattedMessage id="flows.savingsFundOnboarding.termsStep.confirmText" />
-              </label>
-              {showError && (
-                <p className="m-0 text-danger fs-base" role="alert">
-                  <FormattedMessage id="flows.savingsFundOnboarding.termsStep.error" />
-                </p>
-              )}
-              {error && error.message ? (
-                <p className="m-0 text-danger fs-base" role="alert">
-                  {error.message}
-                </p>
-              ) : null}
-            </div>
-          )}
-        />
-      </div>
+      )}
     </section>
   );
 };

--- a/src/test/backend.ts
+++ b/src/test/backend.ts
@@ -935,6 +935,23 @@ export function savingsFundOnboardingStatusBackend(
   );
 }
 
+export function savingsFundDocumentsBackend(server: SetupServerApi): void {
+  server.use(
+    rest.get('http://localhost/v1/savings/documents', (req, res, ctx) =>
+      res(
+        ctx.json({
+          terms:
+            'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+          prospectus:
+            'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
+          keyInformation:
+            'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
+        }),
+      ),
+    ),
+  );
+}
+
 export function savingsAccountStatementBackend(
   server: SetupServerApi,
   statement: FundBalance | null = null,
@@ -997,6 +1014,7 @@ const TEST_BACKENDS = {
   contributions: contributionsBackend,
   businessRegistry: businessRegistryBackend,
   companyValidation: companyValidationBackend,
+  savingsFundDocuments: savingsFundDocumentsBackend,
 } as const;
 
 export type TestBackendName = keyof typeof TEST_BACKENDS;


### PR DESCRIPTION
## What & why

The Täiendav Kogumisfond (TKF100) onboarding **signing step** links three legal documents — **terms, prospectus, key information**. Those URLs were **hardcoded and duplicated** in the two onboarding flow parents and silently went stale when the documents were re-issued (they pointed at the superseded `12.01.2026` versions).

This switches the frontend to read the URLs from the backend: a `useSavingsFundDocuments()` hook calls **`GET /v1/savings/documents`** and the returned URLs are mapped onto the existing `linkText` label ids. WordPress stays the editable source (the backend mirrors it) — **the frontend no longer needs a deploy when the documents change.**

Issue: TulevaEE/TKF-VPII2026#63
Backend (serves the endpoint): TulevaEE/onboarding-service#1647
WordPress prereq (exposes the ACF fields over REST): TulevaEE/wordpress-theme#67

## Changes
- `useSavingsFundDocuments()` react-query hook + `getSavingsFundDocuments()` API fn + `SavingsFundDocuments` type.
- `SavingsFundOnboarding.tsx` and `SavingsFundCompanyOnboarding.tsx` read `documents` from the hook and pass them to `TermsStep` — **the hardcoded arrays are removed**.
- `TermsStep` shows a loading state (shared `Loader`) instead of an empty link list while documents are loading, so the step **never renders linkless mid-load**.
- No translation changes — the `linkText.{terms,prospectus,keyInfo}` labels already exist.

## Tests
Strict TDD, semantic RTL queries. `TermsStep` gets a graceful-loading test; both flow tests supply documents via a mocked `GET /v1/savings/documents` backend, and the happy-flow test asserts the Terms link carries the **API-provided** href (not a constant). Run with:
```
TZ=UTC npx react-scripts test --watchAll=false --no-coverage --reporters=default --reporters=tdd-guard-jest --testPathPattern=savingsAccount/SavingsFundOnboarding
```
Savings onboarding + `TermsStep` suites green (23/23); `tsc --noEmit`, `eslint --max-warnings=0`, and Prettier clean on the changed files.

## Note
Live end-to-end (URLs sourced from real WordPress REST) waits on TulevaEE/wordpress-theme#67 deploying; until then the backend serves a baked-in fallback, so the links are correct regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
