### PR TITLE
Update TKF onboarding signing links to in-force (Feb 2026) documents

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -134,15 +134,15 @@ export const SavingsFundCompanyOnboarding = () => {
           control={control}
           documents={[
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
             },
           ]}

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
@@ -185,6 +185,12 @@ describe('SavingsFundOnboarding', () => {
     expect(
       await screen.findByRole('heading', { name: 'Review fund documents', level: 2 }),
     ).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: /Terms/i })).toHaveAttribute(
+      'href',
+      'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+    );
+
     const termsCheckbox = screen.getByLabelText(
       'I confirm that I have reviewed the documents and understand that the investment may increase or decrease in value over time',
     );

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
@@ -182,15 +182,15 @@ export const SavingsFundOnboarding: FC = () => {
           control={control}
           documents={[
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Tingimused.-12.01.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Prospekt.-12.01.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/01/Tuleva-Taiendav-Kogumisfond.-Pohiteabedokument.-12.01.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
             },
           ]}


### PR DESCRIPTION
## What & why

The TKF100 onboarding **signing step** linked the superseded **12.01.2026** terms, prospectus and key-information PDFs. This points both onboarding flows (personal + company) at the versions **currently in force**:

| Document | URL |
|---|---|
| Tingimused | `…/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf` |
| Prospekt | `…/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf` |
| Põhiteave | `…/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf` |

These are the versions effective today (verified against the live fund-documents page). The newer `15.06.2026` prospekt/tingimused on the page are **not yet effective** and were deliberately not used.

## Scope

Minimal **interim stopgap** — just the hardcoded URLs in `SavingsFundOnboarding.tsx` and `SavingsFundCompanyOnboarding.tsx`. The proper fix (backend serves these from WordPress so the content team can update them without a deploy) is **parked** on branch `tkf-onboarding-document-links` until our CTO can review the design. Tracking: TulevaEE/TKF-VPII2026#63.

## Tests

The happy-flow test now asserts the Terms link carries the in-force href (TDD: red → green). Savings onboarding suites green (109 tests); `tsc`, `eslint --max-warnings=0`, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)