### PR TITLE
TKF #67: company KYB ends on the company account, not the "in review" page

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
@@ -110,7 +110,8 @@ describe('SavingsFundCompanyOnboarding', () => {
     expect(await screen.findByText('2/7')).toBeInTheDocument();
   });
 
-  it('submits survey on the last step and redirects to success', async () => {
+  it('switches to the company account and opens the deposit view when KYB completes', async () => {
+    const switchBackend = switchRoleBackend(server);
     const history = createMemoryHistory();
     renderWrapped(<SavingsFundCompanyOnboarding />, history);
     await selectCompany();
@@ -126,12 +127,39 @@ describe('SavingsFundCompanyOnboarding', () => {
 
     userEvent.click(continueButton());
 
+    // A completed company KYB lands directly on the company's deposit view
+    // (no account chooser for the standalone path), not the "in review" page.
+    await waitFor(() => {
+      expect(switchBackend.switchedRole).toEqual({ type: 'LEGAL_ENTITY', code: '12345678' });
+    });
+    await waitFor(() => {
+      expect(history.location.pathname).toBe('/savings-fund/payment');
+    });
+  });
+
+  it('shows the pending page when the company KYB is rejected', async () => {
+    const history = createMemoryHistory();
+    renderWrapped(<SavingsFundCompanyOnboarding />, history);
+    await selectCompany();
+    await advanceToStep(2);
+    await completeStepsThroughTerms();
+
+    server.use(
+      rest.post('http://localhost/v1/kyb/surveys', (_req, res, ctx) => res(ctx.status(200))),
+      rest.get('http://localhost/v1/savings/onboarding/status/legal-entity', (_req, res, ctx) =>
+        res(ctx.json({ status: 'REJECTED' })),
+      ),
+    );
+
+    userEvent.click(continueButton());
+
     await waitFor(() => {
       expect(history.location.pathname).toBe('/savings-fund/onboarding/pending');
     });
   });
 
   it('includes registry code as query parameter in survey POST', async () => {
+    switchRoleBackend(server);
     await navigateToStep2();
     await completeStepsThroughTerms();
 
@@ -154,6 +182,7 @@ describe('SavingsFundCompanyOnboarding', () => {
   });
 
   it('POSTs survey data to /v1/kyb/surveys on the last step', async () => {
+    switchRoleBackend(server);
     await navigateToStep2();
     await completeStepsThroughTerms();
 
@@ -198,6 +227,7 @@ describe('SavingsFundCompanyOnboarding', () => {
   });
 
   it('disables the continue button while survey is being submitted', async () => {
+    switchRoleBackend(server);
     await navigateToStep2();
     await completeStepsThroughTerms();
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -15,6 +15,7 @@ import { OnboardingWizardLayout } from './OnboardingWizardLayout';
 import {
   useSavingsFundCompanyOnboardingStatus,
   useSubmitSavingsFundCompanyOnboardingSurvey,
+  useSwitchRole,
 } from '../../../common/apiHooks';
 import { transformCompanyFormDataToSurveyCommand } from '../utils';
 
@@ -37,11 +38,32 @@ export const SavingsFundCompanyOnboarding = () => {
   const { data: onboardingStatus } = useSavingsFundCompanyOnboardingStatus(submittedRegistryCode);
   const { mutateAsync: submitSurvey, isPending: submittingSurvey } =
     useSubmitSavingsFundCompanyOnboardingSurvey();
+  const switchRole = useSwitchRole();
 
   useEffect(() => {
-    if (onboardingStatus) {
-      history.push('/savings-fund/onboarding/pending');
+    if (!onboardingStatus) {
+      return;
     }
+    if (onboardingStatus.status === 'COMPLETED' && submittedRegistryCode) {
+      // KYB passed — switch to the new company account and open its deposit
+      // view directly. The standalone company path skips the account chooser
+      // (cf. AccountChoiceStep, used by the both-flow) and lands on the
+      // company's payment view so the deposit is unambiguously to the company
+      // (TKF #67 F7).
+      const openCompanyAccount = async () => {
+        try {
+          await switchRole.mutateAsync({ type: 'LEGAL_ENTITY', code: submittedRegistryCode });
+          history.push('/savings-fund/payment');
+        } catch {
+          setSubmitError(true);
+        }
+      };
+      openCompanyAccount();
+      return;
+    }
+    // REJECTED — legal entities never receive PENDING. Show the generic
+    // "we'll review it" outcome rather than surfacing a hard rejection.
+    history.push('/savings-fund/onboarding/pending');
   }, [onboardingStatus]);
 
   const { control, trigger, handleSubmit, watch } = useForm<CompanyOnboardingFormData>({


### PR DESCRIPTION
## Probleem

Pärast seda kui ettevõte lõpetab eraldiseisva (standalone) KYB-voo, näidati neile alati lehte **„Taotlus on läbivaatamisel"** (`/savings-fund/onboarding/pending`) — ka siis kui ettevõtte tuvastus läks edukalt läbi. Lisaks ei jõudnud nad ettevõtte kontole / sissemakse-vaatesse.

## Põhjus

`SavingsFundCompanyOnboarding.tsx` `useEffect` suunas `/pending`-le iga kord, kui mistahes onboarding-staatus saabus — staatuse **väärtust ei vaadatud**:

```ts
useEffect(() => {
  if (onboardingStatus) {                                 // ainult olemasolu, mitte väärtus
    history.push('/savings-fund/onboarding/pending');
  }
}, [onboardingStatus]);
```

Backend seab juriidilisele isikule aga ainult `COMPLETED` või `REJECTED` (`PENDING` on ainult isiku/KYC oma — vt `LegalEntityOnboardingEventListener`). Seega edukalt tuvastatud ettevõte sattus ekslikult „läbivaatamisel" lehele.

## Lahendus

Hargnemine tegeliku staatuse järgi:
- **`COMPLETED`** → vaheta ettevõtte rolli (`LEGAL_ENTITY`) ja ava otse ettevõtte sissemakse-vaade (`/savings-fund/payment`). See peegeldab juba olemasolevat ja testitud „both-flow" konto-valiku ettevõtte-nuppu (`AccountChoiceStep`), nii et standalone-voog jõuab **otse ettevõtte kontole ilma konto-valiku ekraanita** ja sissemakse on üheselt ettevõtte oma (TKF #67 F7).
- **`REJECTED`** → senine üldine „vaatame läbi" leht (`/pending`), ilma kõva tagasilükkamise teateta.

## Testid

- Parandatud valesti nimetatud test (väitis `/pending`) → kontrollib nüüd rolli vahetust + sissemakse-vaate suunamist.
- Lisatud `REJECTED` → `/pending` test.
- `switchRole` backend mokitud ülejäänud `COMPLETED`-staatusega testides.

Kohalik: kõik 17 testi rohelised, ESLint puhas, `tsc --noEmit` veatu.

Seotud: #67. NB: PIN2-allkirja puudumine ettevõtte voos on **teadlik disain** (TKF on tavaline pangaülekanne, mitte volitusega sammas) — selle PR-i osa ei ole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)