### PR TITLE
Move residency checkbox above PEP question on AML page

### DIFF
--- a/src/components/aml/AmlPage.js
+++ b/src/components/aml/AmlPage.js
@@ -25,8 +25,8 @@ export const AmlPage = ({ save, updateUserSuccess, createAmlChecksSuccess, locat
     </p>
     <UpdateUserForm onSubmit={save}>
       <OccupationAgreement className="mt-3" />
-      <PoliticallyExposedPersonAgreement className="mt-3" />
-      <ResidencyAgreement className="mt-3 mb-4" />
+      <ResidencyAgreement className="mt-3" />
+      <PoliticallyExposedPersonAgreement className="mt-3 mb-4" />
     </UpdateUserForm>
   </div>
 );

--- a/src/components/aml/AmlPage.spec.tsx
+++ b/src/components/aml/AmlPage.spec.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { shallow, ShallowWrapper } from 'enzyme';
 import UpdateUserForm from '../contact-details/updateUserForm';
 import { AmlPage } from './AmlPage';
+import OccupationAgreement from './OccupationAgreement';
+import ResidencyAgreement from './ResidencyAgreement';
+import PoliticallyExposedPersonAgreement from './PoliticallyExposedPersonAgreement';
 
 describe('AML Page', () => {
   let component: ShallowWrapper;
@@ -14,5 +17,16 @@ describe('AML Page', () => {
     const saveUser = () => null;
     component.setProps({ saveUser });
     expect(component.find(UpdateUserForm).length).toBe(1);
+  });
+  it('renders residency above the politically exposed person question', () => {
+    const order = component
+      .find(UpdateUserForm)
+      .children()
+      .map((child) => child.type());
+    expect(order).toEqual([
+      OccupationAgreement,
+      ResidencyAgreement,
+      PoliticallyExposedPersonAgreement,
+    ]);
   });
 });


### PR DESCRIPTION
## What

On the data-update form (AML page), the **"Olen Eesti kodanik või oman Eestis töötamise luba"** checkbox rendered *below* the politically-exposed-person (PEP) block, so it read as if it belonged under the PEP title.

This reorders the form so residency sits directly after occupation and **above** the PEP question.

**New order:** Occupation → Residency → PEP

## Changes

- `AmlPage.js` — move `<ResidencyAgreement>` above `<PoliticallyExposedPersonAgreement>`; swap the `mb-4` bottom margin onto the now-last block (PEP) so spacing is unchanged.
- `AmlPage.spec.tsx` — add a test asserting the child order so it can't silently regress.

No translation, API, or backend changes. The newer savings-account onboarding flow uses separate citizenship/PEP steps and is unaffected.

## Test

- `components/aml/` suite: 30 tests pass (including the new order assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)