### PR TITLE
Prefill default III pillar payment amount

### DIFF
--- a/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/Payment.tsx
@@ -14,13 +14,26 @@ import { PaymentBankButtons } from './PaymentBankButtons';
 import { RecurringPaymentDetails } from './RecurringPaymentDetails';
 import { PaymentSubmitSection } from './PaymentSubmitSection';
 
+const DEFAULT_PAYMENT_AMOUNTS: Record<AvailablePaymentType, string> = {
+  SINGLE: '1000',
+  RECURRING: '200',
+};
+
 export const Payment: React.FunctionComponent = () => {
   useIntl();
 
   const [paymentType, setPaymentType] = useState<AvailablePaymentType>('SINGLE');
-  const [paymentAmount, setPaymentAmount] = useState<string>('');
+  const [paymentAmount, setPaymentAmount] = useState<string>(DEFAULT_PAYMENT_AMOUNTS.SINGLE);
+  const [amountEdited, setAmountEdited] = useState<boolean>(false);
   const [paymentBank, setPaymentBank] = useState<BankKey | 'other' | null>(null);
   const [error, setError] = useState<boolean>(false);
+
+  const handlePaymentTypeChange = (type: AvailablePaymentType) => {
+    setPaymentType(type);
+    if (!amountEdited) {
+      setPaymentAmount(DEFAULT_PAYMENT_AMOUNTS[type]);
+    }
+  };
 
   const { data: user } = useMe();
 
@@ -66,7 +79,7 @@ export const Payment: React.FunctionComponent = () => {
           <FormattedMessage id="thirdPillarPayment.errorGeneratingLink" />
         </div>
       )}
-      <PaymentTypeSelection paymentType={paymentType} setPaymentType={setPaymentType} />
+      <PaymentTypeSelection paymentType={paymentType} setPaymentType={handlePaymentTypeChange} />
       <>
         <PaymentAmountInput
           paymentType={paymentType}
@@ -77,6 +90,7 @@ export const Payment: React.FunctionComponent = () => {
 
             if (value === '' || euroRegex.test(value)) {
               setPaymentAmount(value);
+              setAmountEdited(true);
             }
           }}
           onWheel={(event) => event.currentTarget.blur()}

--- a/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarPaymentStep.test.tsx
+++ b/src/components/flows/thirdPillar/ThirdPillarPayment/ThirdPillarPaymentStep.test.tsx
@@ -49,6 +49,7 @@ describe('When a user is making a third pillar payment', () => {
 
   test('can fill in amount', async () => {
     const input = await amountInput();
+    userEvent.clear(input);
     userEvent.type(input, '23');
     expect(input.value).toBe('23');
   });
@@ -63,6 +64,7 @@ describe('When a user is making a third pillar payment', () => {
     const amount = await amountInput();
     const lhvBank = await lhvButton();
     const makePayment = await makePaymentButton();
+    userEvent.clear(amount);
     userEvent.type(amount, '23');
     userEvent.click(lhvBank);
     userEvent.click(makePayment);
@@ -75,11 +77,37 @@ describe('When a user is making a third pillar payment', () => {
     expect(windowLocation).toHaveBeenCalledTimes(1);
   });
 
+  test('prefills the suggested single payment amount', async () => {
+    const amount = await amountInput();
+    expect(amount.value).toBe('1000');
+  });
+
+  test('prefills the suggested recurring amount when switching to recurring', async () => {
+    const recurringPayment = await recurringPaymentOption();
+    userEvent.click(recurringPayment);
+    await waitFor(() => expect(screen.getByRole('textbox')).toHaveValue('200'));
+  });
+
+  test('can start a one time payment without changing the prefilled amount', async () => {
+    const lhvBank = await lhvButton();
+    const makePayment = await makePaymentButton();
+    userEvent.click(lhvBank);
+    userEvent.click(makePayment);
+
+    await waitFor(() =>
+      expect(windowLocation).toHaveBeenCalledWith(
+        'https://sandbox-payments.montonio.com?payment_token=example.jwt.token.with.1000.EUR.LHV',
+      ),
+    );
+    expect(windowLocation).toHaveBeenCalledTimes(1);
+  });
+
   test('can start a recurring payment', async () => {
     const recurringPayment = await recurringPaymentOption();
     const amount = await amountInput();
     const lhvBank = await lhvButton();
     userEvent.click(recurringPayment);
+    userEvent.clear(amount);
     userEvent.type(amount, '34');
     userEvent.click(lhvBank);
 


### PR DESCRIPTION
## Probleem

Viimase nädala jooksul oli **2 kõnet**, kus inimesed ütlesid, et III sambasse ei saa rakendusest sissemakset teha — panga valimise järel "ei lähe edasi".

Juurpõhjus: summaväljal oli ainult **hall placeholder** (`1000` / `100`), aga tegelik väärtus algas tühjana. Seetõttu jäi "Tee makse" nupp `disabled`-iks **ilma igasuguse tagasisideta**. Inimesed eeldasid, et näidatud summa on juba sees ja et vaja on ainult pank valida → tupik.

## Lahendus

Teen pakutud summa **päris eeltäidetud väärtuseks**, nii et nupp töötab kohe:
- Ühekordne makse: **1000 €**
- Püsimakse: **200 €/kuus**

Väli jääb täielikult muudetavaks — niipea kui kasutaja oma summa trükib, säilib see ka makse tüübi vahetamisel (`amountEdited` lipp ei kirjuta seda üle). Kingituse­voog jäi tahtlikult muutmata (võõrale kontole pole vaikesummal mõtet).

## Testid (range TDD)

- Uus: ühekordsel eeltäidetud `1000`, püsimaksele lülitumisel `200`.
- Uus (kordab teatatud viga): makse algatamine **ilma summat puudutamata** → suunab panka 1000 EUR-ga.
- Olemasolevad summat-trükkivad testid said `clear()` enne `type()`-i (väli pole enam tühi).
- Kõik III samba makse testid rohelised; `tsc --noEmit` ja eslint puhtad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)