### PR TITLE
Add "asset management" (varahaldus) company investment goal

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestmentGoalStep/InvestmentGoalStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/InvestmentGoalStep/InvestmentGoalStep.test.tsx
@@ -25,6 +25,10 @@ const COMPANY_OPTIONS: StepOption[] = [
     labelId: 'flows.savingsFundOnboarding.investmentGoalStep.longTermCompany',
   },
   {
+    value: 'ASSET_MANAGEMENT',
+    labelId: 'flows.savingsFundOnboarding.investmentGoalStep.assetManagementCompany',
+  },
+  {
     value: 'SPECIFIC_GOAL',
     labelId: 'flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany',
   },
@@ -76,10 +80,11 @@ describe('InvestmentGoalStep', () => {
     renderWrapped(<CompanyInvestmentGoalStepWrapper options={COMPANY_OPTIONS} />);
 
     expect(screen.getByText('Long-term growth of company assets')).toBeInTheDocument();
+    expect(screen.getByText('Investing surplus cash (asset management)')).toBeInTheDocument();
     expect(
       screen.getByText('Specific goal (e.g. equipment, property, expansion)'),
     ).toBeInTheDocument();
-    expect(screen.getByText('Active trading, including daily trading')).toBeInTheDocument();
+    expect(screen.getByText('Active trading')).toBeInTheDocument();
     expect(screen.getByText('Other…')).toBeInTheDocument();
     expect(screen.queryByText("Saving for child's future")).not.toBeInTheDocument();
     expect(screen.queryByText('Long-term investment, including pension')).not.toBeInTheDocument();
@@ -91,7 +96,7 @@ describe('InvestmentGoalStep', () => {
     expect(screen.getByText('Long-term investment, including pension')).toBeInTheDocument();
     expect(screen.getByText('Specific goal (home, education, etc.)')).toBeInTheDocument();
     expect(screen.getByText("Saving for child's future")).toBeInTheDocument();
-    expect(screen.getByText('Active trading, including daily trading')).toBeInTheDocument();
+    expect(screen.getByText('Active trading')).toBeInTheDocument();
     expect(screen.getByText('Other…')).toBeInTheDocument();
   });
 });

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.test.tsx
@@ -211,6 +211,80 @@ describe('SavingsFundCompanyOnboarding', () => {
     );
   });
 
+  it('submits an ASSET_MANAGEMENT option when the asset-management goal is chosen', async () => {
+    switchRoleBackend(server);
+    renderWrapped(<SavingsFundCompanyOnboarding />);
+    await selectCompany();
+    await advanceToStep(2);
+    await completeStepsThroughTermsWithGoal(() =>
+      userEvent.click(
+        screen.getByRole('radio', { name: 'Investing surplus cash (asset management)' }),
+      ),
+    );
+
+    let surveyRequestBody: Record<string, unknown> | null = null;
+    server.use(
+      rest.post('http://localhost/v1/kyb/surveys', (req, res, ctx) => {
+        surveyRequestBody = req.body as Record<string, unknown>;
+        return res(ctx.status(200));
+      }),
+      rest.get('http://localhost/v1/savings/onboarding/status/legal-entity', (_req, res, ctx) =>
+        res(ctx.json({ status: 'COMPLETED' })),
+      ),
+    );
+
+    userEvent.click(continueButton());
+
+    await waitFor(() => {
+      expect(surveyRequestBody).not.toBeNull();
+    });
+    expect(surveyRequestBody).toEqual(
+      expect.objectContaining({
+        answers: expect.arrayContaining([
+          { type: 'INVESTMENT_GOALS', value: { type: 'OPTION', value: 'ASSET_MANAGEMENT' } },
+        ]),
+      }),
+    );
+  });
+
+  it('submits free text when "Other" is chosen as the company investment goal', async () => {
+    switchRoleBackend(server);
+    renderWrapped(<SavingsFundCompanyOnboarding />);
+    await selectCompany();
+    await advanceToStep(2);
+    await completeStepsThroughTermsWithGoal(() => {
+      userEvent.click(screen.getByRole('radio', { name: /Other/ }));
+      userEvent.type(screen.getByRole('textbox'), 'Soovin investeerida kinnisvarasse');
+    });
+
+    let surveyRequestBody: Record<string, unknown> | null = null;
+    server.use(
+      rest.post('http://localhost/v1/kyb/surveys', (req, res, ctx) => {
+        surveyRequestBody = req.body as Record<string, unknown>;
+        return res(ctx.status(200));
+      }),
+      rest.get('http://localhost/v1/savings/onboarding/status/legal-entity', (_req, res, ctx) =>
+        res(ctx.json({ status: 'COMPLETED' })),
+      ),
+    );
+
+    userEvent.click(continueButton());
+
+    await waitFor(() => {
+      expect(surveyRequestBody).not.toBeNull();
+    });
+    expect(surveyRequestBody).toEqual(
+      expect.objectContaining({
+        answers: expect.arrayContaining([
+          {
+            type: 'INVESTMENT_GOALS',
+            value: { type: 'TEXT', value: 'Soovin investeerida kinnisvarasse' },
+          },
+        ]),
+      }),
+    );
+  });
+
   it('displays an error when survey submission fails', async () => {
     await navigateToStep2();
     await completeStepsThroughTerms();
@@ -380,6 +454,25 @@ const advanceToTerms = async () => {
 const completeStepsThroughTerms = async () => {
   await advanceToTerms();
   // Step 7: Terms
+  userEvent.click(screen.getByRole('checkbox'));
+};
+
+// Like completeStepsThroughTerms, but the investment goal at step 4 is chosen
+// by the provided callback instead of defaulting to the long-term option.
+const completeStepsThroughTermsWithGoal = async (pickGoal: () => void) => {
+  expect(await screen.findByText('Telliskivi 60/1, 10412 Tallinn')).toBeInTheDocument();
+  await advanceToStep(3);
+  await advanceToStep(4);
+  pickGoal();
+  await advanceToStep(5);
+  userEvent.click(screen.getByRole('radio', { name: '€20,001–€40,000' }));
+  await advanceToStep(6);
+  userEvent.click(screen.getByRole('checkbox', { name: /operates only in Estonia/i }));
+  userEvent.click(
+    screen.getByRole('checkbox', { name: /not sanctioned and does not do business/i }),
+  );
+  userEvent.click(screen.getByRole('checkbox', { name: /not involved in cryptocurrency/i }));
+  await advanceToStep(7);
   userEvent.click(screen.getByRole('checkbox'));
 };
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -132,6 +132,10 @@ export const SavingsFundCompanyOnboarding = () => {
               labelId: 'flows.savingsFundOnboarding.investmentGoalStep.longTermCompany',
             },
             {
+              value: 'ASSET_MANAGEMENT',
+              labelId: 'flows.savingsFundOnboarding.investmentGoalStep.assetManagementCompany',
+            },
+            {
               value: 'SPECIFIC_GOAL',
               labelId: 'flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany',
             },

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
@@ -27,7 +27,12 @@ type Letter =
   | 'Z';
 export type ISO2CountryCode = `${Letter}${Letter}`;
 export type PepSelfDeclaration = 'IS_PEP' | 'IS_NOT_PEP';
-export type InvestmentGoalOption = 'LONG_TERM' | 'SPECIFIC_GOAL' | 'CHILD' | 'TRADING';
+export type InvestmentGoalOption =
+  | 'LONG_TERM'
+  | 'ASSET_MANAGEMENT'
+  | 'SPECIFIC_GOAL'
+  | 'CHILD'
+  | 'TRADING';
 export type InvestableAssetsOption =
   | 'LESS_THAN_20K'
   | 'RANGE_20K_40K'

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1314,7 +1314,7 @@
   "flows.savingsFundOnboarding.investmentGoalStep.longTerm": "Long-term investment, including pension",
   "flows.savingsFundOnboarding.investmentGoalStep.specificGoal": "Specific goal (home, education, etc.)",
   "flows.savingsFundOnboarding.investmentGoalStep.childFuture": "Saving for child's future",
-  "flows.savingsFundOnboarding.investmentGoalStep.activeTrading": "Active trading, including daily trading",
+  "flows.savingsFundOnboarding.investmentGoalStep.activeTrading": "Active trading",
   "flows.savingsFundOnboarding.investmentGoalStep.other": "Other…",
   "flows.savingsFundOnboarding.investmentGoalStep.otherPlaceholder": "Enter investment goal",
   "flows.savingsFundOnboarding.investmentGoalStep.required": "Select an option to continue.",
@@ -1322,6 +1322,7 @@
   "flows.savingsFundOnboarding.investmentGoalStep.longTermCompany": "Long-term growth of company assets",
   "flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany": "Specific goal (e.g. equipment, property, expansion)",
   "flows.savingsFundOnboarding.investmentGoalStep.titleCompany": "What is your company's investment goal?",
+  "flows.savingsFundOnboarding.investmentGoalStep.assetManagementCompany": "Investing surplus cash (asset management)",
 
   "flows.savingsFundOnboarding.investableAssetsStep.title": "How much investable assets do you have?",
   "flows.savingsFundOnboarding.investableAssetsStep.description": "Investable assets are immediately available money and investments that you can sell quickly – for example, money in a bank account or deposit, and stocks, bonds, and funds.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1404,7 +1404,7 @@
   "flows.savingsFundOnboarding.investmentGoalStep.longTerm": "Pikaajaline investeerimine, sh pension",
   "flows.savingsFundOnboarding.investmentGoalStep.specificGoal": "Konkreetne eesmärk (kodu, haridus jms)",
   "flows.savingsFundOnboarding.investmentGoalStep.childFuture": "Lapse tuleviku tarbeks kogumine",
-  "flows.savingsFundOnboarding.investmentGoalStep.activeTrading": "Aktiivne sh igapäevane kauplemine",
+  "flows.savingsFundOnboarding.investmentGoalStep.activeTrading": "Aktiivne kauplemine",
   "flows.savingsFundOnboarding.investmentGoalStep.other": "Muu…",
   "flows.savingsFundOnboarding.investmentGoalStep.otherPlaceholder": "Sisesta investeerimise eesmärk",
   "flows.savingsFundOnboarding.investmentGoalStep.required": "Jätkamiseks tee valik.",
@@ -1412,6 +1412,7 @@
   "flows.savingsFundOnboarding.investmentGoalStep.longTermCompany": "Osaühingu varade pikaajaline kasvatamine",
   "flows.savingsFundOnboarding.investmentGoalStep.specificGoalCompany": "Konkreetne eesmärk (nt seadmed, kinnisvara, laienemine)",
   "flows.savingsFundOnboarding.investmentGoalStep.titleCompany": "Mis on sinu osaühingu investeerimise eesmärk?",
+  "flows.savingsFundOnboarding.investmentGoalStep.assetManagementCompany": "Vaba raha paigutamine (varahaldus)",
 
   "flows.savingsFundOnboarding.investableAssetsStep.title": "Kui palju on sul investeeritavat vara?",
   "flows.savingsFundOnboarding.investableAssetsStep.description": "Investeeritavad varad on kohe kasutatav raha ja investeeringud, mida saad kiiresti müüa – näiteks pangakontol või hoiusel olev raha ning aktsiad, võlakirjad ja fondid.",


### PR DESCRIPTION
## What

Frontend half of TulevaEE/TKF-VPII2026#78. Adds a fourth structured investment goal to **company (OÜ) onboarding** — „Vaba raha paigutamine (varahaldus)" / `ASSET_MANAGEMENT`.

> **Note on „Muu":** free-text „Muu" was **already supported** on the frontend (the shared `InvestmentGoalStep` renders the „Muu" radio + text input and sends `{type:'TEXT', value}`). This PR adds **no functional code** for that — only a regression test that locks the company flow's „Muu" behaviour in. The actual „Muu" fix is entirely backend: [onboarding-service#1679](https://github.com/TulevaEE/onboarding-service/pull/1679) makes the KYB survey *deserialize and store* the free-text payload (it previously failed → the submit step errored). **Merge the backend first**, otherwise the new varahaldus option's submit fails at the API.

## Changes (functional)

- **`types.api.ts`**: add `ASSET_MANAGEMENT` to `InvestmentGoalOption`.
- **`SavingsFundCompanyOnboarding.tsx`**: add the option in display order `LONG_TERM, ASSET_MANAGEMENT, SPECIFIC_GOAL, TRADING`. The shared „Muu" radio is unchanged.
- **Translations** (via `scripts/edit-translation.py`, NBSP-safe):
  - new `investmentGoalStep.assetManagementCompany` = „Vaba raha paigutamine (varahaldus)" / "Investing surplus cash (asset management)";
  - shorten `investmentGoalStep.activeTrading` „Aktiivne sh igapäevane kauplemine" → „Aktiivne kauplemine" (and EN "Active trading, including daily trading" → "Active trading" for parity), per #78 feedback O3. Shared with the personal flow — intended.
- **`InvestmentGoalStep.tsx` and the personal flow are untouched.**

## Tests

Flow-level (MSW, drives the real wizard to submit):
- choosing the asset-management goal POSTs `{type:'OPTION', value:'ASSET_MANAGEMENT'}` (new behaviour);
- choosing „Muu" + free text POSTs `{type:'TEXT', value:'…'}` (regression guard for the already-existing behaviour).

Plus the existing `InvestmentGoalStep` component tests updated for the new option / shortened trading label. `InvestmentGoal*` + `SavingsFundCompanyOnboarding` suites: **22 passed**.

## Out of scope

- AML risk-flag on free-text „Muu" → **#87**.
- Risk warning when no long-term goal is chosen (O11) → still „Aruta" in #78.
- Copy fixes K1/M5/O4/O9 → later small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)