### PR TITLE
Fix white-screen crash in savings-fund BOTH onboarding flow

### DIFF
--- a/src/components/LoggedInApp/LoggedInApp.js
+++ b/src/components/LoggedInApp/LoggedInApp.js
@@ -164,7 +164,11 @@ export class LoggedInApp extends PureComponent {
               path="/savings-fund/onboarding/pending"
               component={SavingsFundOnboardingPending}
             />
-            <Route path="/savings-fund/onboarding" component={SavingsFundOnboarding} />
+            <Route
+              path="/savings-fund/onboarding/uus"
+              render={() => <SavingsFundOnboarding companyOnboardingEnabled />}
+            />
+            <Route exact path="/savings-fund/onboarding" component={SavingsFundOnboarding} />
             <Route
               path="/savings-fund/company/onboarding"
               component={SavingsFundCompanyOnboarding}

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
@@ -336,6 +336,14 @@ describe('SavingsFundOnboarding', () => {
     expect((history.location.state as { fromBothFlow?: boolean } | undefined)?.fromBothFlow).toBe(
       true,
     );
+
+    // The KYB destination must actually render. Before the fix the wizard
+    // crashed on this transition (white screen), so asserting only the pathname
+    // was a false green — assert the company step's UI is on screen.
+    expect(
+      await screen.findByRole('heading', { level: 2, name: "Enter your company's name" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('1/7')).toBeInTheDocument();
   });
 
   it('allows navigation back through steps', async () => {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react';
 import { useForm, FieldPath, Control } from 'react-hook-form';
-import { useHistory } from 'react-router-dom';
+import { useHistory, Redirect } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { captureException } from '@sentry/browser';
 import { usePageTitle } from '../../../common/usePageTitle';
@@ -24,17 +24,20 @@ import { ErrorResponse } from '../../../common/apiModels';
 import { OnboardingWizardLayout } from './OnboardingWizardLayout';
 
 // Pre-launch preview (TKF #67). The investment-intent step and the company (KYB)
-// branching are reachable ONLY on this unlisted URL until the 15 June 2026 launch.
-// The public /savings-fund/onboarding route keeps the original personal-only flow.
+// branching are reachable ONLY when companyOnboardingEnabled is set, which the
+// router passes solely on the unlisted /savings-fund/onboarding/uus route until
+// the 15 June 2026 launch. The prop is read from the route (not derived from the
+// live pathname) so a mid-flow history.push can't flip it false before unmount
+// and crash the wizard. The public /savings-fund/onboarding route renders this
+// component without the prop, keeping the original personal-only flow.
 //
 // Going live on 2026-06-15 is a pure code change — the public URL stays the same,
 // we just stop hiding the new flow. No feature flag / config / env toggle:
-//   1. Make `companyOnboardingEnabled` always true (see below) — the public
-//      /savings-fund/onboarding then renders the intent flow.
+//   1. Pass companyOnboardingEnabled on the public route too (or default it true)
+//      so /savings-fund/onboarding renders the intent flow.
 //   2. Delete the now-dead personal-only branch in buildSteps (the
-//      `if (!companyOnboardingEnabled)` early return) and this constant + its uses.
-//   3. Land the separate role-switcher "Lisan ettevõtte" PR.
-const COMPANY_ONBOARDING_PREVIEW_PATH = '/savings-fund/onboarding/uus';
+//      `if (!companyOnboardingEnabled)` early return).
+//   3. Remove the /uus route and land the role-switcher "Lisan ettevõtte" PR.
 
 type OnboardingStep = {
   component: JSX.Element;
@@ -173,15 +176,12 @@ const buildSteps = (
     : [...identitySteps, intentStep, ...profileSteps];
 };
 
-export const SavingsFundOnboarding: FC = () => {
+export const SavingsFundOnboarding: FC<{ companyOnboardingEnabled?: boolean }> = ({
+  companyOnboardingEnabled = false,
+}) => {
   usePageTitle('pageTitle.savingsFundOnboarding');
 
   const history = useHistory();
-
-  // TODO(2026-06-15) go-live: replace with `const companyOnboardingEnabled = true;`
-  // (then remove COMPANY_ONBOARDING_PREVIEW_PATH and the dead branch in buildSteps).
-  // Until then the intent + company flow is reachable only on the unlisted preview URL.
-  const companyOnboardingEnabled = history.location.pathname === COMPANY_ONBOARDING_PREVIEW_PATH;
 
   const [activeSection, setActiveSection] = useState(0);
   const [submitError, setSubmitError] = useState<ErrorResponse | null>(null);
@@ -294,6 +294,9 @@ export const SavingsFundOnboarding: FC = () => {
   };
 
   const showNextSection = async () => {
+    if (!steps[activeSection]) {
+      return;
+    }
     const fieldsToValidate = steps[activeSection].fields;
     const isStepValid = await trigger(fieldsToValidate);
 
@@ -332,6 +335,18 @@ export const SavingsFundOnboarding: FC = () => {
     setActiveSection((current) => Math.min(current + 1, totalSections - 1));
   };
 
+  // Fail closed: a topology change must never dereference past the array and
+  // white-screen the wizard. The route-level prop fixes the known cause; this
+  // guards any future one — surface it to Sentry and fall back to a known route
+  // rather than crashing the React tree.
+  const currentStep = steps[activeSection];
+  if (!currentStep) {
+    captureException(
+      new Error(`SavingsFundOnboarding: no step at ${activeSection}/${steps.length}`),
+    );
+    return <Redirect to="/savings-fund/onboarding" />;
+  }
+
   return (
     <div className="col-12 col-md-10 col-lg-7 mx-auto">
       <OnboardingWizardLayout
@@ -342,7 +357,7 @@ export const SavingsFundOnboarding: FC = () => {
         loading={!onboardingStatus && loadingOnboardingStatus}
         submitting={submittingSurvey}
       >
-        {steps[activeSection].component}
+        {currentStep.component}
 
         {submitError ? (
           <div className="alert alert-danger" role="alert">


### PR DESCRIPTION
## Probleem

JI testimisel (TulevaEE/TKF-VPII2026#88): `/savings-fund/onboarding/uus` → kavatsus **"mõlemad" (BOTH)** → terve küsitlus lõpuni → viimasel "Edasi" **tühi valge leht** `/savings-fund/company/onboarding`.

`TypeError: Cannot read properties of undefined (reading 'component')`.

## Juurpõhjus

`companyOnboardingEnabled` tuletati **elavast `history.location.pathname`'ist**. Viimane "Edasi" teeb `history.push('/savings-fund/company/onboarding')`; connected-react-router dispatchib `LOCATION_CHANGE` **sünkroonselt**, mis renderdab veel mountitud komponendi **enne** marsruudi-vahetust. Sellel renderdusel pathname ≠ `/uus` → lipp `false` → 8-sammuline isiklik massiiv, aga `activeSection = 8` → `steps[8]` `undefined` → viskab → React-puu kokku → valge leht.

## Parandus

- **Route-level prop:** `companyOnboardingEnabled` tuleb nüüd marsruudilt (`/uus` route annab `render={() => <SavingsFundOnboarding companyOnboardingEnabled />}`), mitte komponendis pathname'ist tuletatud — nii ei saa see vahe-renderdusel `false`'iks minna enne unmount'i.
- **`exact` avalikul route'il:** `/savings-fund/onboarding` on nüüd `exact`, eemaldab footguni, et tulevased `/savings-fund/onboarding/<x>` ei tabaks vaikselt sama komponenti.
- **Fail-closed guard:** kui `steps[activeSection]` puudub → `captureException` (Sentry) + `<Redirect>` kontrollitud route'ile, mitte valge leht. Teine kaitsekiht iga tulevase topoloogia-muutuse vastu.

## Test

Olemasolev "both-flow context" test oli **false green** — kontrollis ainult `pathname`'i, mis krahhi üle elas. Tugevdatud: pärast viimast "Continue" assert nüüd, et **KYB sihtkoht renderdub** ("Enter your company's name" + "1/7").

## Verifitseerimine

- `SavingsFundOnboarding.test` → **6/6, 0 krahhi** (RED kinnitatud enne fixi: tühi `<body>`)
- `SavingsFund|LoggedInApp` serial → **188/188**
- `tsc --noEmit` puhas · `eslint --max-warnings=0` puhas

## Go-live (2026-06-15) — deletion discipline

Go-live = anna prop ka avalikul route'il (või default `true`), eemalda `/uus` route + dead `if (!companyOnboardingEnabled)` haru. Soovitus: eraldi tracked cleanup-issue tähtajaga 2026-06-15, et koristus ei ununeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)