### PR TITLE
Login: "Sisene oma pensionikontole" → "Sisene oma kontole"

### DIFF
--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1,5 +1,5 @@
 {
-  "login.title": "Log in to your pension account",
+  "login.title": "Log in to your account",
   "login.subtitle": "Anyone can log in. Even if you are not yet in Tuleva.",
   "login.title.thirdPillar.withExchange": "You want to change your III pillar pension fund and make a monthly contribution of {monthlyContribution} euros",
   "login.title.thirdPillar.withoutExchange": "You want to select III pillar pension fund and make a monthly contribution of {monthlyContribution} euros",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1,5 +1,5 @@
 {
-  "login.title": "Sisene oma pensionikontole",
+  "login.title": "Sisene oma kontole",
   "login.subtitle": "Sisse logida saab igaüks. Ka siis, kui veel Tulevas ei kogu.",
   "login.title.thirdPillar.withExchange": "Soovid oma III samba fondiosakud vahetada ning teha III sambasse sissemakse {monthlyContribution} eurot kuus",
   "login.title.thirdPillar.withoutExchange": "Soovid valida III samba pensionifondi ning teha III sambasse sissemakse {monthlyContribution} eurot kuus",


### PR DESCRIPTION
Eemaldab sõna **"pensioni"** sisselogimislehe pealkirjast (`login.title`).

| | enne | pärast |
|---|---|---|
| ET | Sisene oma pensionikontole | **Sisene oma kontole** |
| EN | Log in to your pension account | **Log in to your account** |

**Miks:** sisse logida saab igaüks, ka need kes Tulevas veel ei kogu (seda ütleb juba alapealkiri "Sisse logida saab igaüks. Ka siis, kui veel Tulevas ei kogu."). "Pensionikontole" oli liiga kitsendav.

Muudatus puudutab ainult kahte i18n stringi (`translations.et.json`, `translations.en.json`). Kasutuskoht: `src/components/login/loginForm/LoginForm.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)