### PR TITLE
TKF: selgitav tooltip "Osaühing tegutseb ainult Eestis" kinnitusele

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/CompanyIncomeSourceStep/CompanyIncomeSourceStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/CompanyIncomeSourceStep/CompanyIncomeSourceStep.test.tsx
@@ -66,6 +66,14 @@ describe('CompanyIncomeSourceStep', () => {
     ).toBeInTheDocument();
   });
 
+  it('explains the only-active-in-Estonia statement in a tooltip', () => {
+    renderWrapped(<CompanyIncomeSourceStepWrapper />);
+
+    expect(
+      screen.getByText(/The company has no permanent place of business abroad/i),
+    ).toBeInTheDocument();
+  });
+
   it('explains what counts as crypto business in a tooltip', () => {
     renderWrapped(<CompanyIncomeSourceStepWrapper />);
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/CompanyIncomeSourceStep/CompanyIncomeSourceStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/CompanyIncomeSourceStep/CompanyIncomeSourceStep.tsx
@@ -13,6 +13,7 @@ const CHECKBOX_OPTIONS: ReadonlyArray<{
   {
     key: 'ONLY_ACTIVE_IN_ESTONIA',
     labelId: 'flows.savingsFundOnboarding.companyIncomeSourceStep.onlyActiveInEstonia',
+    tooltipId: 'flows.savingsFundOnboarding.companyIncomeSourceStep.onlyActiveInEstonia.tooltip',
   },
   {
     key: 'NOT_SANCTIONED_NOT_PROFITING_FROM_SANCTIONED_COUNTRIES',

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1287,6 +1287,7 @@
   "flows.savingsFundOnboarding.companyIncomeSourceStep.title": "I confirm the following",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.description": "I confirm that",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.onlyActiveInEstonia": "The company operates only in Estonia",
+  "flows.savingsFundOnboarding.companyIncomeSourceStep.onlyActiveInEstonia.tooltip": "The company has no permanent place of business abroad. Selling goods and services abroad is allowed.",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.notSanctioned": "The company is not sanctioned and does not do business with sanctioned countries or persons",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.notInCrypto": "The company is not involved in cryptocurrency activities",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.notInCrypto.tooltip": "Crypto business means the company's activity consists of producing, brokering, buying or selling crypto-assets. If the company only invests its own assets in crypto-assets (buying and selling them as an investment), that is not crypto business and does not fall under this.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1377,6 +1377,7 @@
   "flows.savingsFundOnboarding.companyIncomeSourceStep.title": "Kinnitan järgnevat",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.description": "Kinnitan, et",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.onlyActiveInEstonia": "Osaühing tegutseb ainult Eestis",
+  "flows.savingsFundOnboarding.companyIncomeSourceStep.onlyActiveInEstonia.tooltip": "Osaühingul ei ole välismaal püsivat tegevuskohta. Kaupa ja teenuste müük välismaale on lubatud.",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.notSanctioned": "Pole sanktsioneeritud ega tee äri sanktsioneeritud riikide ega isikutega",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.notInCrypto": "Ei tegutse krüptoäris",
   "flows.savingsFundOnboarding.companyIncomeSourceStep.notInCrypto.tooltip": "Krüptoäri tähendab, et ettevõtte tegevus seisneb krüptovara tootmises, vahendamises, ostmises või müügis. Kui ettevõte üksnes investeerib oma vara krüptovarasse (ostab ja müüb seda investeeringuna), ei loeta seda krüptoäriks ja siia see alla ei kuulu.",


### PR DESCRIPTION
## Mida

Ettevõtte TKF onboardingu kinnituste sammus (`CompanyIncomeSourceStep`) lisab esimesele kinnitusele **"Osaühing tegutseb ainult Eestis"** väikese selgitava tooltipi — sama `InfoTooltip` muster, mis krüptoäri kinnitusel juba olemas on.

Tooltip tekst:
> Osaühingul ei ole välismaal püsivat tegevuskohta. Kaupa ja teenuste müük välismaale on lubatud.

## Miks

Sõnastus "tegutseb ainult Eestis" tekitas segadust: paljud Eesti osaühingud müüvad kaupa või teenuseid välismaale, kuid neil ei ole välismaal püsivat tegevuskohta. Selgitus aitab juhatajal kinnituse rahuliku südamega anda.

## Muudatused

- `CompanyIncomeSourceStep.tsx` — `ONLY_ACTIVE_IN_ESTONIA` valikule `tooltipId`
- `translations.et.json` / `translations.en.json` — uus võti `...onlyActiveInEstonia.tooltip`
- `CompanyIncomeSourceStep.test.tsx` — test, et selgitus tooltipis kuvatakse

Komponenditestid: 8/8 ✓

Closes TulevaEE/TKF-VPII2026#91

🤖 Generated with [Claude Code](https://claude.com/claude-code)