### PR TITLE
feat: add fund summary to savings fund terms step (O10)

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.test.tsx
@@ -89,6 +89,28 @@ describe('TermsStep', () => {
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Review fund documents');
   });
 
+  test('renders the fund summary as plain bullet points', () => {
+    renderWrapped(<TermsStepWrapper />);
+
+    expect(screen.getByRole('heading', { name: 'Fund in brief' })).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(4);
+
+    expect(screen.getByText('Fee 0.28% per year, no additional fees')).toBeInTheDocument();
+    expect(
+      screen.getByText('A broad-based index fund investing in global equities'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The value can fluctuate from year to year, so it is best suited for long-term investing',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Flexible withdrawals – money reaches your account within three business days',
+      ),
+    ).toBeInTheDocument();
+  });
+
   test('renders links to all fund documents', () => {
     renderWrapped(<TermsStepWrapper />);
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/TermsStep/TermsStep.tsx
@@ -11,6 +11,13 @@ type TermsStepProps<T extends SharedOnboardingFields = SharedOnboardingFields> =
   confirmTextId?: TranslationKey;
 };
 
+const SUMMARY_BULLETS: TranslationKey[] = [
+  'flows.savingsFundOnboarding.termsStep.summary.fee',
+  'flows.savingsFundOnboarding.termsStep.summary.strategy',
+  'flows.savingsFundOnboarding.termsStep.summary.risk',
+  'flows.savingsFundOnboarding.termsStep.summary.withdrawals',
+];
+
 export const TermsStep = <T extends SharedOnboardingFields = SharedOnboardingFields>({
   control,
   documents,
@@ -26,6 +33,18 @@ export const TermsStep = <T extends SharedOnboardingFields = SharedOnboardingFie
         </h2>
       </div>
       <div className="section-content d-flex flex-column gap-5">
+        <div className="d-flex flex-column gap-3 bg-light border border-gray-2 rounded-3 p-3 p-sm-4">
+          <h3 className="m-0 fs-5 fw-bold">
+            <FormattedMessage id="flows.savingsFundOnboarding.termsStep.summary.title" />
+          </h3>
+          <ul className="m-0 ps-3 d-flex flex-column gap-2">
+            {SUMMARY_BULLETS.map((id) => (
+              <li key={id}>
+                <FormattedMessage id={id} />
+              </li>
+            ))}
+          </ul>
+        </div>
         <div className="d-flex flex-column gap-3">
           {documents.map(({ href, labelId }) => (
             <DocumentLink key={href} href={href}>

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1359,6 +1359,12 @@
   "flows.savingsFundOnboarding.termsStep.confirmText": "I confirm that I have reviewed the documents and understand that the investment may increase or decrease in value over time",
   "flows.savingsFundOnboarding.termsStep.error": "You must review the documents to continue.",
   "flows.savingsFundOnboarding.termsStep.confirmTextCompany": "I confirm on behalf of the company that I have reviewed the documents and understand that the investment may increase or decrease in value over time",
+  "flows.savingsFundOnboarding.termsStep.summary.title": "Fund in brief",
+  "flows.savingsFundOnboarding.termsStep.summary.fee": "Fee 0.28% per year, no additional fees",
+  "flows.savingsFundOnboarding.termsStep.summary.strategy": "A broad-based index fund investing in global equities",
+  "flows.savingsFundOnboarding.termsStep.summary.risk": "The value can fluctuate from year to year, so it is best suited for long-term investing",
+  "flows.savingsFundOnboarding.termsStep.summary.withdrawals": "Flexible withdrawals – money reaches your account within three business days",
+
   "flows.savingsFundOnboarding.investmentIntentStep.title": "How do you want to invest?",
   "flows.savingsFundOnboarding.investmentIntentStep.description": "This determines which questions we ask next.",
   "flows.savingsFundOnboarding.investmentIntentStep.self": "Only personally",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1449,6 +1449,12 @@
   "flows.savingsFundOnboarding.termsStep.confirmText": "Kinnitan, et olen dokumentidega tutvunud ja mõistan, et investeering võib ajas nii kasvada kui kahaneda",
   "flows.savingsFundOnboarding.termsStep.error": "Jätkamiseks pead dokumentidega tutvuma.",
   "flows.savingsFundOnboarding.termsStep.confirmTextCompany": "Kinnitan ettevõtte nimel, et olen dokumentidega tutvunud ja mõistan, et investeering võib ajas nii kasvada kui kahaneda",
+  "flows.savingsFundOnboarding.termsStep.summary.title": "Lühidalt Täiendavast Kogumisfondist",
+  "flows.savingsFundOnboarding.termsStep.summary.fee": "Tasu 0,28% aastas, lisatasudeta",
+  "flows.savingsFundOnboarding.termsStep.summary.strategy": "Laiapõhjaline indeksfond, mis investeerib maailma aktsiatesse",
+  "flows.savingsFundOnboarding.termsStep.summary.risk": "Fondi väärtus võib aastati kõikuda, seega sobib pikaajaliseks investeerimiseks",
+  "flows.savingsFundOnboarding.termsStep.summary.withdrawals": "Paindlikud väljamaksed – raha laekub kontole kolme tööpäeva jooksul",
+
   "flows.savingsFundOnboarding.investmentIntentStep.title": "Kuidas soovid investeerida?",
   "flows.savingsFundOnboarding.investmentIntentStep.description": "See määrab, milliseid küsimusi järgmisena küsime.",
   "flows.savingsFundOnboarding.investmentIntentStep.self": "Ainult isiklikult",


### PR DESCRIPTION
## What

Adds a short **"Fund in brief"** summary box at the top of the terms step (above the document links), so users get the key parameters at a glance before reviewing the documents and confirming. Addresses user-testing feedback O10 ("the terms page should include a summary of the key parameters — fees, strategy").

Bullet points cover:
- Fee — 0.28% per year, no additional fees
- Strategy — broad-based index fund investing in global equities
- Risk — value can fluctuate, best suited for long-term investing
- Withdrawals — flexible, money in account within three business days

Shown in **both** the individual and company onboarding flows (shared `TermsStep`).

## Design

Box styling (`bg-light`, `border-gray-2`, `rounded-3`, `p-3 p-sm-4`) matches the existing document cards and company-data card in the flow; the box heading uses a lighter `fs-5` so it does not compete with the step title.

## Note

The fee figure (0.28%) and the T+3 withdrawal timing should be confirmed against the current key information document before merge.

## Testing

- `TermsStep` suite updated; full `SavingsFundOnboarding` suite passes (109 tests)

Ref: TulevaEE/TKF-VPII2026#78 (O10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)