### PR TITLE
fix: greet the representative on legal entity account page (K1)

### DIFF
--- a/src/components/account/RepresentedPartyAccountPage.test.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.test.tsx
@@ -51,8 +51,8 @@ describe('RepresentedPartyAccountPage', () => {
     history.push('/account');
   });
 
-  test('renders a greeting with company name', async () => {
-    expect(await screen.findByText(/Hi, Acme OÜ/)).toBeInTheDocument();
+  test('greets the company representative', async () => {
+    expect(await screen.findByText('Hi, Acme OÜ representative')).toBeInTheDocument();
   });
 
   test('renders savings fund overview with deposit and withdraw links', async () => {

--- a/src/components/account/RepresentedPartyAccountPage.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.tsx
@@ -14,7 +14,7 @@ export function RepresentedPartyAccountPage() {
     <section aria-label="represented-party-account">
       {user && (
         <p className="my-5 m-0 lead">
-          <FormattedMessage id="account.greeting" />, {user.role.name}
+          <FormattedMessage id="account.legalEntity.greeting" values={{ name: user.role.name }} />
         </p>
       )}
 

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -349,6 +349,7 @@
   "update.user.thanks": "Thanks!",
   "update.user.success.message": "Your details have been updated.",
   "account.second.pillar.missing": "You have not joined the II pillar. What are your options? 1. Those born 1970 or later can join again II pillar from 01.01.2020 onwards. 2. Start saving into Tuleva III Pillar Pension Fund.",
+  "account.legalEntity.greeting": "Hi, {name} representative",
   "pension.registry.connection.exception": "Couldn’t connect to the Estonian Pension Registry, please try again.",
   "change.my.pension.fund": "Change II pillar fund",
   "change.my.pension.fund.third.pillar": "Change III pillar fund",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -372,6 +372,7 @@
   "update.user.thanks": "Tänud!",
   "update.user.success.message": "Sinu andmed on uuendatud.",
   "account.second.pillar.missing": "Sa ei ole II sambaga liitunud. Millised võimalused sul tulevikus on? 1. 1970 ja hiljem sündinud saavad alates 1.01.2020 II sambaga uuesti liituda. 2. Hakka koguma Tuleva III Samba Pensionifondi.",
+  "account.legalEntity.greeting": "Tere, {name} esindaja",
   "pension.registry.connection.exception": "Ei saa ühendust Eesti väärtpaberite keskregistriga, palun proovi hetke pärast uuesti.",
   "change.my.pension.fund": "Vahetan fondi",
   "change.my.pension.fund.third.pillar": "Vahetan fondi",


### PR DESCRIPTION
## What

On the legal entity account page the greeting read **"Hi, <company>"**, which isn't quite right — the logged-in person is the company's **representative**, not the company. Changed to **"Hi, <company> representative"** (ET: "Tere, <company> esindaja").

Uses a dedicated `account.legalEntity.greeting` message with a `{name}` placeholder so word order stays correct per language. The person greeting (`account.greeting`, used by `GreetingBar`) is unchanged.

Addresses user-testing feedback K1.

## Testing

- `LegalEntityAccountPage` suite green (6 tests)

Ref: TulevaEE/TKF-VPII2026#78 (K1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)