### PR TITLE
Reword login permission note copy

### DIFF
--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -20,7 +20,7 @@
   "login.error.generic": "Sisselogimisel tekkis viga. Palun proovi uuesti.",
   "login.join.tuleva": "Liitu!",
   "login.or": "või",
-  "login.permission.note": "Sisenedes annad ühekordse loa küsida pensioniregistrist sinu andmed ja nõustud Tuleva <a>privaatsuspoliitikaga</a>.",
+  "login.permission.note": "Sisenedes annad ühekordse loa küsida pensioniregistrist su andmed ja oled teadlik Tuleva <a>privaatsuspoliitikast</a>.",
   "login.permission.note.url": "https://tuleva.ee/privaatsuspoliitika-ja-veebilehe-kasutustingimused/",
   "login.not.member": "Sa pole veel Tuleva liige?",
   "login.apply.link": "Täida liitumisavaldus",


### PR DESCRIPTION
Small copy tweak on the login screen permission note (Estonian).

**Before:** Sisenedes annad ühekordse loa küsida pensioniregistrist **sinu** andmed ja **nõustud** Tuleva [privaatsuspoliitikaga].

**After:** Sisenedes annad ühekordse loa küsida pensioniregistrist **su** andmed ja **oled teadlik** Tuleva [privaatsuspoliitikast].

The privacy policy link is preserved. Edited via `scripts/edit-translation.py` to keep intentional NBSPs intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)