### PR TITLE
Show copy-fields UI for company Swedbank recurring payments

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -495,5 +495,20 @@ describe(SavingsFundPayment, () => {
       expect(screen.queryByText(/paying from an/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/investment account/i)).not.toBeInTheDocument();
     });
+
+    it('shows a copy-card for Swedbank recurring because the business page has no pre-fill', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
+      userEvent.click(screen.getByRole('radio', { name: 'Swedbank' }));
+
+      expect(
+        await screen.findByRole('heading', { name: 'Set up the recurring payment in Swedbank' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Copy these details into your bank')).toBeInTheDocument();
+      expect(screen.queryByText('Check the details')).not.toBeInTheDocument();
+      expect(screen.getByText('EE711010220306707220')).toBeInTheDocument();
+      expect(screen.getByText('12345678')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
@@ -63,6 +63,11 @@ export const SavingsFundRecurringDetails: FC<Props> = ({
   isLegalEntity,
 }) => {
   const meta = BANK_META[bank];
+  // Swedbank only pre-fills the private standing-order form. Legal entities are
+  // sent to the business page, which has no pre-fill, so they copy the fields
+  // manually like any other LANDING bank.
+  const linkBehavior: LinkBehavior =
+    bank === 'SWEDBANK' && isLegalEntity ? 'LANDING' : meta.linkBehavior;
   const hasAmount = Number.isFinite(amount) && (amount ?? 0) >= 1;
   const { data, isLoading, isFetching, isError } = useQuery<PaymentLink>({
     queryKey: ['paymentLink', 'SAVINGS_RECURRING', meta.channel ?? null, amount, personalCode],
@@ -103,7 +108,7 @@ export const SavingsFundRecurringDetails: FC<Props> = ({
           </h3>
 
           <PaymentStep number={1}>
-            {meta.linkBehavior === 'MANUAL' ? (
+            {linkBehavior === 'MANUAL' ? (
               <FormattedMessage id="savingsFund.recurring.step.openBank.generic" />
             ) : (
               <FormattedMessage
@@ -114,7 +119,7 @@ export const SavingsFundRecurringDetails: FC<Props> = ({
           </PaymentStep>
 
           <PaymentStep number={2}>
-            {meta.linkBehavior === 'PREFILLED' ? (
+            {linkBehavior === 'PREFILLED' ? (
               <>
                 <FormattedMessage id="savingsFund.recurring.step.review" />
                 <div className="mt-3 p-3 p-md-4 payment-details-table">
@@ -183,7 +188,7 @@ export const SavingsFundRecurringDetails: FC<Props> = ({
         <Link to="/account" className="btn btn-outline-primary">
           <FormattedMessage id="savingsFund.payment.form.cancel.label" />
         </Link>
-        {meta.linkBehavior !== 'MANUAL' && bankUrl && !isFetching && (
+        {linkBehavior !== 'MANUAL' && bankUrl && !isFetching && (
           <a
             href={bankUrl}
             target="_blank"


### PR DESCRIPTION
## Problem

Part of [TKF-VPII2026#75](https://github.com/TulevaEE/TKF-VPII2026/issues/75). The backend now sends **company** savings-fund recurring payers to Swedbank's **business** standing-order page, which **cannot be pre-filled**. But the recurring panel treated Swedbank as `PREFILLED` for everyone — showing *"Check the details"* with read-only rows (no copy buttons). A company user would land on an empty business form with no easy way to copy the IBAN / reference / amount.

## Fix

In `SavingsFundRecurringDetails`, derive an effective `linkBehavior`: Swedbank stays `PREFILLED` for private persons, but becomes `LANDING` for legal entities — so companies get the copy-fields card and *"Copy these details into your bank"*, matching the no-pre-fill business page.

Backend counterpart: onboarding-service [#1692](https://github.com/TulevaEE/onboarding-service/pull/1692).

## Tests

Added "shows a copy-card for Swedbank recurring because the business page has no pre-fill" to the company block of `SavingsFundPayment.spec.tsx`. All 31 specs in the suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
