### PR TITLE
Update TKF onboarding signing links to in-force (15.06.2026) documents

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundCompanyOnboarding.tsx
@@ -191,15 +191,15 @@ export const SavingsFundCompanyOnboarding = () => {
           confirmTextId="flows.savingsFundOnboarding.termsStep.confirmTextCompany"
           documents={[
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Tingimused-kehtib-alates-15.06.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Prospekt-kehtib-alates-15.06.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/06/TKF100-Pohiteave-kehtib-alates-15.06.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
             },
           ]}

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.test.tsx
@@ -232,7 +232,7 @@ describe('SavingsFundOnboarding', () => {
 
     expect(screen.getByRole('link', { name: /Terms/i })).toHaveAttribute(
       'href',
-      'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+      'https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Tingimused-kehtib-alates-15.06.2026.pdf',
     );
 
     const termsCheckbox = screen.getByLabelText(

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundOnboarding.tsx
@@ -147,15 +147,15 @@ const buildSteps = (
           control={control}
           documents={[
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Tingimused-kehtib-alates-15.06.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.terms',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/05/TKF100-Prospekt-kehtib-alates-15.06.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.prospectus',
             },
             {
-              href: 'https://tuleva.ee/wp-content/uploads/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf',
+              href: 'https://tuleva.ee/wp-content/uploads/2026/06/TKF100-Pohiteave-kehtib-alates-15.06.2026.pdf',
               labelId: 'flows.savingsFundOnboarding.termsStep.linkText.keyInfo',
             },
           ]}


### PR DESCRIPTION
## What

The document-signing step in **both** savings-fund onboarding flows (private `SavingsFundOnboarding` and company `SavingsFundCompanyOnboarding`) linked to the Feb 2026 TKF document set. The **15.06.2026** set is now in force on tuleva.ee, so update all three links.

| Document | Was | Now |
|---|---|---|
| Tingimused | `…/2026/02/Tuleva.eurofond.tingimused.02.02.2026.pdf` | `…/2026/05/TKF100-Tingimused-kehtib-alates-15.06.2026.pdf` |
| Prospekt | `…/2026/02/TKF100-Prospekt-kehtib-alates-27.02.2026.pdf` | `…/2026/05/TKF100-Prospekt-kehtib-alates-15.06.2026.pdf` |
| Põhiteave | `…/2026/02/Pohiteave-TKF100-kehtib-alates-27.02.2026.pdf` | `…/2026/06/TKF100-Pohiteave-kehtib-alates-15.06.2026.pdf` |

Note: the **Tingimused** filename convention changed (now `TKF100-Tingimused-…` instead of `Tuleva.eurofond.tingimused…`), so it was pulled verbatim from the live documents page rather than pattern-substituted.

## Verification

- All three new URLs return **HTTP 200** (checked against tuleva.ee).
- URLs match the current rendered links on the public docs page `tuleva-taiendav-kogumisfond-dokumendid`.
- Updated the one integration-test assertion in `SavingsFundOnboarding.test.tsx` that pins the Terms link.

## Context

This is the recurring interim fix tracked in TulevaEE/TKF-VPII2026#63 (prior occurrence: #1558). The systematic WordPress-sourced solution remains parked pending CTO review.

Refs TulevaEE/TKF-VPII2026#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)