### PR TITLE
Hide II/III pillar transaction links for TKF company view

### DIFF
--- a/src/components/account/TransactionSection/TransactionSection.test.tsx
+++ b/src/components/account/TransactionSection/TransactionSection.test.tsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { IntlProvider } from 'react-intl';
 import { TransactionSection } from './TransactionSection';
 import { contribution, subtraction } from './fixtures';
-import { fundsBackend } from '../../../test/backend';
+import { fundsBackend, userBackend } from '../../../test/backend';
 import { initializeConfiguration } from '../../config/config';
 import { getAuthentication } from '../../common/authenticationManager';
 import { anAuthenticationManager } from '../../common/authenticationManagerFixture';
@@ -48,6 +48,7 @@ describe('Transaction section', () => {
     initializeConfiguration();
     getAuthentication().update(anAuthenticationManager());
     fundsBackend(server);
+    userBackend(server);
   });
 
   it('does not render at all when there has been an error fetching', async () => {
@@ -155,6 +156,23 @@ describe('Transaction section', () => {
       'href',
       `/transaction/${contribution.id}`,
     );
+  });
+
+  it('shows II and III pillar navigation links on the savings fund page when acting as self', async () => {
+    mockTransactions([]);
+    initializeComponent({ pillar: null });
+    expect(await screen.findByText('transactions.title')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'transactions.seeAll.2' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'transactions.seeAll.3' })).toBeInTheDocument();
+  });
+
+  it('hides II and III pillar navigation links when representing a company', async () => {
+    userBackend(server, { role: { type: 'LEGAL_ENTITY', code: '12345678', name: 'ACME OÜ' } });
+    mockTransactions([]);
+    initializeComponent({ pillar: null });
+    expect(await screen.findByText('transactions.title')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'transactions.seeAll.2' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'transactions.seeAll.3' })).not.toBeInTheDocument();
   });
 
   function mockTransactions(transactions: any[]) {

--- a/src/components/account/TransactionSection/TransactionSection.tsx
+++ b/src/components/account/TransactionSection/TransactionSection.tsx
@@ -4,12 +4,12 @@ import { captureException } from '@sentry/browser';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import sumBy from 'lodash/sumBy';
-import { useFunds, useTransactions } from '../../common/apiHooks';
+import { useFunds, useMe, useTransactions } from '../../common/apiHooks';
 import Table from '../../common/table';
 import { Euro } from '../../common/Euro';
 import { Shimmer } from '../../common/shimmer/Shimmer';
 import { formatDate } from '../../common/dateFormatter';
-import { formatAmountForCount } from '../../common/utils';
+import { formatAmountForCount, isActingAsSelf } from '../../common/utils';
 import { Breakpoint, TableColumn } from '../../common/table/Table';
 import { getOtherTransactionPages } from './getOtherTransactionPages';
 
@@ -21,6 +21,7 @@ export const TransactionSection: React.FunctionComponent<{
 }> = ({ limit, pillar, children, allTransactionsPath }) => {
   const { data: transactions = [], isLoading: transactionsLoading } = useTransactions();
   const { data: funds = [], isLoading: fundsLoading } = useFunds();
+  const { data: user, isLoading: userLoading } = useMe();
 
   if (!Array.isArray(transactions) || !Array.isArray(funds)) {
     captureException(
@@ -35,6 +36,7 @@ export const TransactionSection: React.FunctionComponent<{
   if (
     transactionsLoading ||
     fundsLoading ||
+    userLoading ||
     !Array.isArray(transactions) ||
     !Array.isArray(funds)
   ) {
@@ -62,7 +64,7 @@ export const TransactionSection: React.FunctionComponent<{
     fundTransactions = fundTransactions.filter((transaction) => transaction.pillar === pillar);
   }
 
-  const otherPages = getOtherTransactionPages(pillar, funds);
+  const otherPages = getOtherTransactionPages(pillar, funds, isActingAsSelf(user));
 
   const amountSum = sumBy(fundTransactions, (transaction) => transaction.amount);
 

--- a/src/components/account/TransactionSection/getOtherTransactionPages.test.tsx
+++ b/src/components/account/TransactionSection/getOtherTransactionPages.test.tsx
@@ -18,7 +18,7 @@ function fund(pillar: number | null): Fund {
 describe('getOtherTransactionPages', () => {
   it('from 2nd pillar with all fund types, returns 3rd pillar and savings fund pages', () => {
     const funds = [fund(2), fund(3), fund(null)];
-    expect(getOtherTransactionPages(2, funds)).toEqual([
+    expect(getOtherTransactionPages(2, funds, true)).toEqual([
       { pillar: 3, path: '/3rd-pillar-transactions', labelId: 'transactions.seeAll.3' },
       {
         pillar: null,
@@ -30,7 +30,7 @@ describe('getOtherTransactionPages', () => {
 
   it('from 3rd pillar with all fund types, returns 2nd pillar and savings fund pages', () => {
     const funds = [fund(2), fund(3), fund(null)];
-    expect(getOtherTransactionPages(3, funds)).toEqual([
+    expect(getOtherTransactionPages(3, funds, true)).toEqual([
       { pillar: 2, path: '/2nd-pillar-transactions', labelId: 'transactions.seeAll.2' },
       {
         pillar: null,
@@ -42,23 +42,42 @@ describe('getOtherTransactionPages', () => {
 
   it('from savings fund with all fund types, returns 2nd pillar and 3rd pillar pages', () => {
     const funds = [fund(2), fund(3), fund(null)];
-    expect(getOtherTransactionPages(null, funds)).toEqual([
+    expect(getOtherTransactionPages(null, funds, true)).toEqual([
       { pillar: 2, path: '/2nd-pillar-transactions', labelId: 'transactions.seeAll.2' },
       { pillar: 3, path: '/3rd-pillar-transactions', labelId: 'transactions.seeAll.3' },
     ]);
   });
 
   it('with two fund types, returns the one other page', () => {
-    expect(getOtherTransactionPages(2, [fund(2), fund(3)])).toEqual([
+    expect(getOtherTransactionPages(2, [fund(2), fund(3)], true)).toEqual([
       { pillar: 3, path: '/3rd-pillar-transactions', labelId: 'transactions.seeAll.3' },
     ]);
   });
 
   it('with only one fund type, returns empty array', () => {
-    expect(getOtherTransactionPages(2, [fund(2)])).toEqual([]);
+    expect(getOtherTransactionPages(2, [fund(2)], true)).toEqual([]);
   });
 
   it('when pillar is undefined, returns empty array', () => {
-    expect(getOtherTransactionPages(undefined, [fund(2), fund(3), fund(null)])).toEqual([]);
+    expect(getOtherTransactionPages(undefined, [fund(2), fund(3), fund(null)], true)).toEqual([]);
+  });
+
+  it('when representing a party (not acting as self), hides II and III pillar pages', () => {
+    const funds = [fund(2), fund(3), fund(null)];
+    // A company / represented party only has savings fund; from the savings fund page
+    // there should be no other pillar links to show.
+    expect(getOtherTransactionPages(null, funds, false)).toEqual([]);
+  });
+
+  it('when representing a party, only the savings fund page remains available', () => {
+    const funds = [fund(2), fund(3), fund(null)];
+    // Even if somehow on a pillar page, a represented party gets only the savings link.
+    expect(getOtherTransactionPages(2, funds, false)).toEqual([
+      {
+        pillar: null,
+        path: '/savings-fund-transactions',
+        labelId: 'transactions.seeAll.savingsFund',
+      },
+    ]);
   });
 });

--- a/src/components/account/TransactionSection/getOtherTransactionPages.ts
+++ b/src/components/account/TransactionSection/getOtherTransactionPages.ts
@@ -20,16 +20,22 @@ const allPages: TransactionPage[] = [
 export function getOtherTransactionPages(
   pillar: number | null | undefined,
   funds: Fund[],
+  actingAsSelf: boolean,
 ): TransactionPage[] {
   if (pillar === undefined) {
     return [];
   }
 
-  const availablePages = allPages.filter((page) =>
-    page.pillar == null
+  const availablePages = allPages.filter((page) => {
+    // A represented party (company or child) has no II/III pillar — the backend only
+    // returns savings-fund transactions for them (TransactionService.isActingAsSelf gate).
+    if (page.pillar != null && !actingAsSelf) {
+      return false;
+    }
+    return page.pillar == null
       ? funds.some((fund) => fund.pillar == null)
-      : funds.some((fund) => fund.pillar === page.pillar),
-  );
+      : funds.some((fund) => fund.pillar === page.pillar);
+  });
 
   return availablePages.filter((page) => page.pillar !== pillar);
 }


### PR DESCRIPTION
## Problem

When a board member switches into a **company** role (or a parent represents a child) and opens the TKF savings-fund transactions page (`/savings-fund-transactions`), the page shows **"II sammas" / "III sammas"** navigation links — even though a represented party has no II/III pillar.

These are not transaction rows; they are cross-navigation links produced by `getOtherTransactionPages()`, which decided the available pillar pages purely from the global `/v1/funds` catalog. That catalog always contains II and III pillar funds regardless of who is viewing, and there was no acting-entity check, so the links always rendered.

The backend is already correct: `TransactionService` returns only savings-fund transactions for a represented party (`isActingAsSelf` gate), so no II/III pillar **data** reaches the company view — only these frontend links leaked.

## Fix

- `getOtherTransactionPages(pillar, funds, actingAsSelf)` — new `actingAsSelf` param; when representing a party, II/III pillar pages are excluded (only the savings-fund page is available). Mirrors the backend gate.
- `TransactionSection` reads `useMe()` and passes `isActingAsSelf(user)`. It also waits for `useMe()` in the loading guard so self users don't briefly lose their pillar links while the user loads (`isActingAsSelf(undefined) === false`).
- No i18n changes (existing keys reused).

## Tests (strict TDD)

- `getOtherTransactionPages.test.tsx`: represented mode hides II/III pages; only savings remains.
- `TransactionSection.test.tsx`: self sees the II/III links; a company (`role.type = 'LEGAL_ENTITY'`) does not.
- Full `components/account` suite green (197 tests), `tsc --noEmit` clean.

## Not in scope (flagged)

Direct URLs `/2nd-pillar-transactions` and `/3rd-pillar-transactions` remain reachable; for a represented party the list would just be empty (backend is gated — no data leak). A route-level guard could be added as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Design note — represented children (for review)

`isActingAsSelf` is false for **both** a company (`LEGAL_ENTITY`) and a parent representing a **child** (`PERSON`, where `role.code` = the child's personal code ≠ the parent's `personalCode`). So this change hides the II/III pillar links for a represented child too.

That is intentional and consistent with the backend: `TransactionService.getTransactions` (commit c561093f0, "Limit account statements to user acting as themselves") already returns **only** savings-fund transactions for any represented party — child included — and `/v1/pension-account-statement` returns an empty list for them. So today those II/III links already lead to **empty pages** for a represented child; this PR just removes the dead links.

**Open question for the reviewer:** a child *can* have a III pillar — should a parent be able to see/manage a child's III pillar in the represented view? If yes, that's a backend change first (loosen the `isActingAsSelf` gate for represented children), and this frontend predicate should then follow the same rule. Out of scope for this PR.
