### PR TITLE
Align savings fund payment confirmation copy with email (2 business days)

### DIFF
--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1202,7 +1202,7 @@
 
   "savingsFund.payment.success.pageTitle": "Deposit made",
   "savingsFund.payment.success.title": "Deposit made",
-  "savingsFund.payment.success.description": "The deposit amount will be invested in the fund by the end of next business day. We will notify you of this by email.",
+  "savingsFund.payment.success.description": "The deposit amount will be invested in the fund within two business days. We will notify you of this by email.",
   "savingsFund.payment.investmentAccountReminder": "Using an investment account? Check that the payer account is correct.",
   "savingsFund.payment.accountOwner": "Deposit to: {accountOwner}",
 

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1284,7 +1284,7 @@
 
   "savingsFund.payment.success.pageTitle": "Sissemakse tehtud",
   "savingsFund.payment.success.title": "Sissemakse on tehtud",
-  "savingsFund.payment.success.description": "Sissemakse summa investeeritakse fondi järgneva tööpäeva lõpuks. Teavitame sind sellest meili teel.",
+  "savingsFund.payment.success.description": "Sissemakse summa investeeritakse fondi kahe tööpäeva jooksul. Teavitame sind sellest meili teel.",
   "savingsFund.payment.investmentAccountReminder": "Kasutad investeerimiskontot? Kontrolli, et maksja konto oleks õige.",
   "savingsFund.payment.accountOwner": "Sissemakse: {accountOwner}",
 


### PR DESCRIPTION
## Probleem

Täiendava Kogumisfondi (TKF) sissemakse **edu-ekraan** ja **kinnitusemail** andsid kliendile erineva lubaduse selle kohta, millal raha investeeritakse:

- **UI** (`savingsFund.payment.success.description`): *"...investeeritakse fondi **järgneva tööpäeva** lõpuks..."* / *"by the end of next business day"*
- **Email** (Mandrill `savings_fund_payment_success_et`/`_en`): *"...**kahe tööpäeva** jooksul..."* / *"within two business days"*

Kaks eri lubadust sama sissemakse kohta tekitab kliendile segadust.

## Lahendus

Ühtlusta **UI email'i peale** — muuda edu-ekraani tekst "kahe tööpäeva jooksul" / "within two business days". Emaili Mandrilli malli **ei** puudutata.

**Miks see suund:** arvelduse loogika (`onboarding-service` `PaymentReservationFilterService`, **16:00 lõikepunkt** tööpäeval) tähendab, et enne 16:00 makstes jõuab raha tüüpiliselt järgmiseks tööpäevaks, aga pärast 16:00 / nädalavahetusel kuni kaks tööpäeva. Seega **"kahe tööpäeva jooksul" on alati tõene** ja valiti kanooniliseks sõnastuseks. Sten kinnitas suuna.

## Muudatus

Üks tõlkevõti, kaks keelt (muudetud `scripts/edit-translation.py`-ga, NBSP-turvaline):

| | Vana | Uus |
|---|---|---|
| ET | ...järgneva tööpäeva lõpuks... | ...kahe tööpäeva jooksul... |
| EN | ...by the end of next business day... | ...within two business days... |

EN "within two business days" ja ET "kahe tööpäeva jooksul" järgivad savings-fundi pere maja-stiili (`kolme tööpäeva jooksul` / `within three business days`, `ühe tööpäeva jooksul` / `within one business day`).

## Ei muudetud
- Klassikalise III samba tekste (juba "2 tööpäeva" peal kooskõlas).
- `applications.type.savingFundPayment.fulfillmentNotice` (dünaamiline `{fulfillmentDeadline}`, andmepõhine).
- Emaili Mandrilli malle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)