### PR TITLE
Track millionaire calculator clicks

### DIFF
--- a/src/components/millionaire/MillionaireCalculator.test.tsx
+++ b/src/components/millionaire/MillionaireCalculator.test.tsx
@@ -23,6 +23,7 @@ import {
   UserConversion,
 } from '../common/apiModels';
 import translations from '../translations';
+import { createTrackedEvent } from '../common/api';
 import { buildComparison, TULEVA_FEE } from './calculation';
 import { derivePrefill } from './prefill';
 
@@ -35,6 +36,10 @@ jest.mock('../common/apiHooks', () => ({
   useSavingsFundOnboardingStatus: jest.fn(),
   useSavingsFundBalance: jest.fn(),
   useTransactions: jest.fn(),
+}));
+
+jest.mock('../common/api', () => ({
+  createTrackedEvent: jest.fn(),
 }));
 
 jest.mock('react-chartjs-2', () => ({
@@ -66,6 +71,7 @@ const mockUseSavingsFundBalance = useSavingsFundBalance as jest.MockedFunction<
   typeof useSavingsFundBalance
 >;
 const mockUseTransactions = useTransactions as jest.MockedFunction<typeof useTransactions>;
+const mockCreateTrackedEvent = createTrackedEvent as jest.MockedFunction<typeof createTrackedEvent>;
 
 // Not converted to Tuleva in either pillar, so all three next steps are actionable.
 const notAtTuleva = {
@@ -205,6 +211,12 @@ describe('MillionaireCalculator', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(now);
+    // CRA sets resetMocks: true, so implementations have to be re-armed here or
+    // createTrackedEvent returns undefined and the fire-and-forget .catch() blows up.
+    mockCreateTrackedEvent.mockResolvedValue(undefined);
+    // getCurrentPath() reads the real jsdom location, which MemoryRouter never
+    // touches; park it on the page under test so the tracked path is realistic.
+    window.history.pushState({}, '', '/millionaire');
     mockUseConversion.mockReturnValue({ data: undefined } as ReturnType<typeof useConversion>);
     mockUseFunds.mockReturnValue({ data: [] } as unknown as ReturnType<typeof useFunds>);
     mockUseSavingsFundOnboardingStatus.mockReturnValue({ data: { status: null } } as ReturnType<
@@ -470,6 +482,75 @@ describe('MillionaireCalculator', () => {
       '/2nd-pillar-payment-rate',
     );
     expect(linkIn('cta-item-thirdPillarToTuleva')).toHaveAttribute('href', '/3rd-pillar-flow');
+  });
+
+  it('tracks which next step the saver clicked', () => {
+    givenData();
+    renderCalculator();
+
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(within(screen.getByTestId('cta-item-secondPillarToTuleva')).getByRole('link'));
+
+    expect(mockCreateTrackedEvent).toHaveBeenCalledWith('CLICK', {
+      path: '/millionaire',
+      target: 'millionaireCalculator.ctaButton',
+      value: 'secondPillarToTuleva',
+      url: '/2nd-pillar-flow',
+    });
+  });
+
+  it('tracks each next step separately, so sends can tell them apart', () => {
+    givenData();
+    renderCalculator();
+
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(within(screen.getByTestId('cta-item-raiseSecondPillar')).getByRole('link'));
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(within(screen.getByTestId('cta-item-thirdPillarToTuleva')).getByRole('link'));
+
+    expect(mockCreateTrackedEvent).toHaveBeenCalledTimes(2);
+    expect(mockCreateTrackedEvent).toHaveBeenNthCalledWith(
+      1,
+      'CLICK',
+      expect.objectContaining({ value: 'raiseSecondPillar', url: '/2nd-pillar-payment-rate' }),
+    );
+    expect(mockCreateTrackedEvent).toHaveBeenNthCalledWith(
+      2,
+      'CLICK',
+      expect.objectContaining({ value: 'thirdPillarToTuleva', url: '/3rd-pillar-flow' }),
+    );
+  });
+
+  it('tracks the II pillar rate the saver picked', () => {
+    givenData();
+    renderCalculator();
+
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(screen.getByRole('button', { name: '6%' }));
+
+    expect(mockCreateTrackedEvent).toHaveBeenCalledWith('CLICK', {
+      path: '/millionaire',
+      target: 'millionaireCalculator.setSecondPillarRate',
+      value: 6,
+    });
+  });
+
+  it('keeps quiet until the saver actually interacts', () => {
+    givenData();
+    renderCalculator();
+
+    expect(mockCreateTrackedEvent).not.toHaveBeenCalled();
+  });
+
+  it('still navigates when tracking fails', () => {
+    mockCreateTrackedEvent.mockRejectedValueOnce(new Error('tracking is down'));
+    givenData();
+    renderCalculator();
+
+    const link = within(screen.getByTestId('cta-item-secondPillarToTuleva')).getByRole('link');
+    // eslint-disable-next-line testing-library/prefer-user-event
+    expect(() => fireEvent.click(link)).not.toThrow();
+    expect(link).toHaveAttribute('href', '/2nd-pillar-flow');
   });
 
   it('checks off raising the II pillar rate once the saver already contributes 6%', () => {

--- a/src/components/millionaire/MillionaireCalculator.test.tsx
+++ b/src/components/millionaire/MillionaireCalculator.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
-import { MemoryRouter } from 'react-router-dom';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { MillionaireCalculator } from './MillionaireCalculator';
 import {
   useContributions,
@@ -91,14 +92,16 @@ const atTulevaContributing = {
   contribution: { yearToDate: 500, lastYear: 6000, total: 12000 },
 } as Conversion;
 
-const renderCalculator = () =>
+// Takes a history so a test can assert where a CTA actually took the saver.
+const renderCalculator = (history = createMemoryHistory({ initialEntries: ['/millionaire'] })) => {
   render(
-    <MemoryRouter>
+    <Router history={history}>
       <IntlProvider locale="en" messages={translations.en}>
         <MillionaireCalculator />
       </IntlProvider>
-    </MemoryRouter>,
+    </Router>,
   );
+};
 
 const user = (overrides: Partial<User> = {}): User =>
   ({
@@ -489,7 +492,7 @@ describe('MillionaireCalculator', () => {
     renderCalculator();
 
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(within(screen.getByTestId('cta-item-secondPillarToTuleva')).getByRole('link'));
+    fireEvent.click(screen.getByRole('link', { name: 'Switch to Tuleva' }));
 
     expect(mockCreateTrackedEvent).toHaveBeenCalledWith('CLICK', {
       path: '/millionaire',
@@ -504,9 +507,10 @@ describe('MillionaireCalculator', () => {
     renderCalculator();
 
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(within(screen.getByTestId('cta-item-raiseSecondPillar')).getByRole('link'));
+    fireEvent.click(screen.getByRole('link', { name: 'Raise my contribution' }));
+    // The label carries a non-breaking space, so match it with \s rather than ' '.
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.click(within(screen.getByTestId('cta-item-thirdPillarToTuleva')).getByRole('link'));
+    fireEvent.click(screen.getByRole('link', { name: /Open a III\spillar/ }));
 
     expect(mockCreateTrackedEvent).toHaveBeenCalledTimes(2);
     expect(mockCreateTrackedEvent).toHaveBeenNthCalledWith(
@@ -535,6 +539,23 @@ describe('MillionaireCalculator', () => {
     });
   });
 
+  // The arrow shortcut is aria-hidden, so only the hint link is reachable by role;
+  // `source` is what separates the two in the analytics.
+  it('marks the hint link as the source when it sets the historical return', () => {
+    givenData();
+    renderCalculator();
+
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(screen.getByRole('button', { name: /return 7%/ }));
+
+    expect(mockCreateTrackedEvent).toHaveBeenCalledWith('CLICK', {
+      path: '/millionaire',
+      target: 'millionaireCalculator.setHistoricalReturn',
+      value: 7,
+      source: 'hintLink',
+    });
+  });
+
   it('keeps quiet until the saver actually interacts', () => {
     givenData();
     renderCalculator();
@@ -545,12 +566,13 @@ describe('MillionaireCalculator', () => {
   it('still navigates when tracking fails', () => {
     mockCreateTrackedEvent.mockRejectedValueOnce(new Error('tracking is down'));
     givenData();
-    renderCalculator();
+    const history = createMemoryHistory({ initialEntries: ['/millionaire'] });
+    renderCalculator(history);
 
-    const link = within(screen.getByTestId('cta-item-secondPillarToTuleva')).getByRole('link');
     // eslint-disable-next-line testing-library/prefer-user-event
-    expect(() => fireEvent.click(link)).not.toThrow();
-    expect(link).toHaveAttribute('href', '/2nd-pillar-flow');
+    fireEvent.click(screen.getByRole('link', { name: 'Switch to Tuleva' }));
+
+    expect(history.location.pathname).toBe('/2nd-pillar-flow');
   });
 
   it('checks off raising the II pillar rate once the saver already contributes 6%', () => {

--- a/src/components/millionaire/MillionaireCalculator.tsx
+++ b/src/components/millionaire/MillionaireCalculator.tsx
@@ -17,6 +17,8 @@ import { Line } from 'react-chartjs-2';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { usePageTitle } from '../common/usePageTitle';
+import { createTrackedEvent } from '../common/api';
+import { getCurrentPath } from '../account/ComparisonCalculator/utility';
 import './MillionaireCalculator.scss';
 import {
   useContributions,
@@ -208,6 +210,14 @@ type CtaItem = {
 // Anyone with money still sitting in another fund (even a cheap one) gets nudged.
 const fullyConverted = (pillar: Conversion): boolean =>
   pillar.selectionComplete && pillar.transfersComplete;
+
+// Fire-and-forget, like ComparisonCalculator: tracking must never break a click.
+// Note we do NOT preventDefault the way ComparisonCalculator does — these are
+// react-router <Link>s, so navigation keeps the document alive and the in-flight
+// POST completes on its own.
+const trackClick = (target: string, data: Record<string, unknown> = {}): void => {
+  createTrackedEvent('CLICK', { path: getCurrentPath(), target, ...data }).catch(() => {});
+};
 
 export function MillionaireCalculator() {
   const intl = useIntl();
@@ -626,6 +636,12 @@ export function MillionaireCalculator() {
                       'btn w-100 w-sm-auto',
                       item.primary ? 'btn-primary' : 'btn-outline-primary',
                     )}
+                    onClick={() =>
+                      trackClick('millionaireCalculator.ctaButton', {
+                        value: item.id,
+                        url: item.link,
+                      })
+                    }
                   >
                     <FormattedMessage id={item.buttonKey} />
                   </Link>
@@ -694,7 +710,13 @@ export function MillionaireCalculator() {
                           active ? 'btn-primary' : 'btn-outline-primary',
                         )}
                         aria-pressed={active}
-                        onClick={() => update({ currentSecondPillarRate: active ? 0 : rate })}
+                        onClick={() => {
+                          const newRate = active ? 0 : rate;
+                          trackClick('millionaireCalculator.setSecondPillarRate', {
+                            value: newRate,
+                          });
+                          update({ currentSecondPillarRate: newRate });
+                        }}
                       >
                         {rate}%
                       </button>
@@ -792,7 +814,12 @@ export function MillionaireCalculator() {
                     type="button"
                     tabIndex={-1}
                     aria-hidden="true"
-                    onClick={() => update({ annualReturnPercent: HISTORICAL_RETURN })}
+                    onClick={() => {
+                      trackClick('millionaireCalculator.setHistoricalReturn', {
+                        value: HISTORICAL_RETURN,
+                      });
+                      update({ annualReturnPercent: HISTORICAL_RETURN });
+                    }}
                     className="btn p-0 border-0 bg-transparent position-absolute lh-1 text-secondary"
                     style={{
                       // Centre on the thumb: the track travel is (100% - thumbWidth)
@@ -814,7 +841,12 @@ export function MillionaireCalculator() {
                       a: (chunks: React.ReactNode) => (
                         <button
                           type="button"
-                          onClick={() => update({ annualReturnPercent: HISTORICAL_RETURN })}
+                          onClick={() => {
+                            trackClick('millionaireCalculator.setHistoricalReturn', {
+                              value: HISTORICAL_RETURN,
+                            });
+                            update({ annualReturnPercent: HISTORICAL_RETURN });
+                          }}
                           className="btn btn-link p-0 border-0 align-baseline"
                           style={{ fontSize: 'inherit', verticalAlign: 'baseline' }}
                         >

--- a/src/components/millionaire/MillionaireCalculator.tsx
+++ b/src/components/millionaire/MillionaireCalculator.tsx
@@ -219,7 +219,7 @@ const fullyConverted = (pillar: Conversion): boolean =>
 // absolute href: relative rows are the ones that match across local, staging and
 // prod, so the analytics stay comparable between environments.
 const trackClick = (target: string, data: Record<string, unknown> = {}): void => {
-  createTrackedEvent('CLICK', { path: getCurrentPath(), target, ...data }).catch(() => {});
+  createTrackedEvent('CLICK', { ...data, path: getCurrentPath(), target }).catch(() => {});
 };
 
 export function MillionaireCalculator() {

--- a/src/components/millionaire/MillionaireCalculator.tsx
+++ b/src/components/millionaire/MillionaireCalculator.tsx
@@ -215,6 +215,9 @@ const fullyConverted = (pillar: Conversion): boolean =>
 // Note we do NOT preventDefault the way ComparisonCalculator does — these are
 // react-router <Link>s, so navigation keeps the document alive and the in-flight
 // POST completes on its own.
+// `url` is deliberately the relative route, where ComparisonCalculator logs an
+// absolute href: relative rows are the ones that match across local, staging and
+// prod, so the analytics stay comparable between environments.
 const trackClick = (target: string, data: Record<string, unknown> = {}): void => {
   createTrackedEvent('CLICK', { path: getCurrentPath(), target, ...data }).catch(() => {});
 };
@@ -817,6 +820,7 @@ export function MillionaireCalculator() {
                     onClick={() => {
                       trackClick('millionaireCalculator.setHistoricalReturn', {
                         value: HISTORICAL_RETURN,
+                        source: 'arrow',
                       });
                       update({ annualReturnPercent: HISTORICAL_RETURN });
                     }}
@@ -844,6 +848,7 @@ export function MillionaireCalculator() {
                           onClick={() => {
                             trackClick('millionaireCalculator.setHistoricalReturn', {
                               value: HISTORICAL_RETURN,
+                              source: 'hintLink',
                             });
                             update({ annualReturnPercent: HISTORICAL_RETURN });
                           }}


### PR DESCRIPTION
## Why

`/millionaire` has had **no click tracking** since it shipped. The only signal today is the global `PAGE_VIEW` in `src/index.jsx` — we know someone arrived, but nothing about whether they acted. Every send to this page is currently blind.

## What

Applies the existing `ComparisonCalculator` pattern — `createTrackedEvent('CLICK', { path, target, value })` from `src/components/common/api.ts`, reusing `getCurrentPath()` — to `MillionaireCalculator`:

| target | fires on | `value` |
|---|---|---|
| `millionaireCalculator.ctaButton` | any next-step CTA | item id (`secondPillarToTuleva`, `raiseSecondPillar`, `thirdPillarToTuleva`, `savingsFund`) + `url` |
| `millionaireCalculator.setSecondPillarRate` | II pillar 2/4/6% toggle | the chosen rate (`0` on de-select) |
| `millionaireCalculator.setHistoricalReturn` | the ↑ arrow and the "historical 7%" link | `7` |

The CTAs render from a single `<Link>` site, so one handler covers all four next steps.

## Notes for review

- **No `preventDefault`.** `ComparisonCalculator` does `preventDefault()` + `window.location.href = url` because it wraps a plain `<a>`. These are react-router `<Link>`s — doing the same would force a full page reload and kill SPA navigation. Fire-and-forget is safe here: SPA nav keeps the document alive, so the in-flight POST completes.
- **Sliders deliberately untracked.** Their `onChange` fires per pixel of drag; tracking it would be event spam, not signal. Worth a follow-up with a commit-on-release handler if the engagement signal is wanted.
- **`getCurrentPath()` is imported across feature folders** (`../account/ComparisonCalculator/utility`). Slightly awkward, but preferred over duplicating a one-liner. Happy to lift it into `common/` if reviewers prefer.

## Testing

5 new tests; **84/84 pass** across the millionaire suites, `tsc` and ESLint clean.

Two things worth flagging that the tests surfaced:
- CRA sets **`resetMocks: true`**, which strips mock implementations — a naive `jest.mock` factory made `createTrackedEvent` return `undefined` and the fire-and-forget `.catch()` threw, breaking two *pre-existing* tests. The implementation is now armed in `beforeEach`, matching how the `apiHooks` mocks already work in this file.
- `getCurrentPath()` reads the real jsdom location, which `MemoryRouter` never touches (it would have asserted a meaningless `''`). `beforeEach` now parks the URL on `/millionaire` so the tracked path is realistic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)