### PR TITLE
Show child third pillar to legal representative

### DIFF
--- a/src/components/account/RepresentedPartyAccountPage.test.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.test.tsx
@@ -82,6 +82,40 @@ describe('RepresentedPartyAccountPage', () => {
     expect(await screen.findByText('Pending applications and transactions')).toBeInTheDocument();
     expect(screen.getByText(/deposit to Additional Savings Fund/)).toBeInTheDocument();
   });
+
+  test('does not show a third pillar section for a represented company', async () => {
+    expect(await screen.findByText(additionalSavingsFund.fund.name)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /III\spillar/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('Tuleva III Samba Pensionifond')).not.toBeInTheDocument();
+  });
+});
+
+describe('RepresentedPartyAccountPage for a represented child', () => {
+  beforeEach(() => {
+    initializeConfiguration();
+    useTestBackendsExcept(server, ['user']);
+    userBackend(server, {
+      role: { type: 'PERSON', code: '61508110000', name: 'Kid Doe' },
+    });
+    savingsAccountStatementBackend(server);
+    initializeComponent();
+    history.push('/account');
+  });
+
+  test("shows the child's third pillar holdings", async () => {
+    expect(
+      await screen.findByRole('heading', { name: /III\spillar/, level: 3 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Tuleva III Samba Pensionifond')).toBeInTheDocument();
+  });
+
+  test('does not show second pillar funds for the child', async () => {
+    expect(
+      await screen.findByRole('heading', { name: /III\spillar/, level: 3 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Tuleva World Stocks Pension Fund')).not.toBeInTheDocument();
+    expect(screen.queryByText('Swedbank Pension Fund K60')).not.toBeInTheDocument();
+  });
 });
 
 describe('RepresentedPartyAccountPage without savings fund balance', () => {

--- a/src/components/account/RepresentedPartyAccountPage.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.tsx
@@ -4,12 +4,21 @@ import AccountStatement from './AccountStatement';
 import { SectionHeading } from './SectionHeading';
 import { TransactionSection } from './TransactionSection/TransactionSection';
 import { ApplicationSection } from './ApplicationSection/ApplicationSection';
-import { useMe, useSavingsFundBalance } from '../common/apiHooks';
+import { useMe, useSavingsFundBalance, useSourceFunds } from '../common/apiHooks';
 
 export function RepresentedPartyAccountPage() {
   const { data: user } = useMe();
   const { data: savingsFundBalance, isLoading: savingsFundBalanceLoading } =
     useSavingsFundBalance();
+
+  // Only a represented person (e.g. a parent viewing a child) can have a third pillar;
+  // a represented legal entity (company) never does, so skip the request for them.
+  const isRepresentedPerson = user?.role.type === 'PERSON';
+  const { data: sourceFunds } = useSourceFunds(undefined, undefined, {
+    enabled: isRepresentedPerson,
+  });
+  const thirdPillarFunds = (sourceFunds ?? []).filter((fund) => fund.pillar === 3);
+  const showThirdPillar = isRepresentedPerson && thirdPillarFunds.length > 0;
 
   // While the balance loads (e.g. right after a role switch), pass undefined so
   // AccountStatement shimmers instead of rendering an empty zero-balance table.
@@ -22,6 +31,13 @@ export function RepresentedPartyAccountPage() {
         <p className="my-5 m-0 lead">
           <FormattedMessage id="account.legalEntity.greeting" values={{ name: user.role.name }} />
         </p>
+      )}
+
+      {showThirdPillar && (
+        <>
+          <SectionHeading titleId="accountStatement.thirdPillar.heading" />
+          <AccountStatement funds={thirdPillarFunds} />
+        </>
       )}
 
       <SectionHeading titleId="accountStatement.savingsFund.heading">

--- a/src/components/common/apiHooks.ts
+++ b/src/components/common/apiHooks.ts
@@ -185,10 +185,15 @@ export function useConversion(): UseQueryResult<UserConversion> {
   return useQuery({ queryKey: ['conversion'], queryFn: () => getUserConversionWithToken() });
 }
 
-export function useSourceFunds(fromDate?: string, toDate?: string): UseQueryResult<SourceFund[]> {
+export function useSourceFunds(
+  fromDate?: string,
+  toDate?: string,
+  options: { enabled?: boolean } = {},
+): UseQueryResult<SourceFund[]> {
   return useQuery({
     queryKey: ['sourceFunds', fromDate, toDate],
     queryFn: () => getSourceFunds(fromDate, toDate),
+    enabled: options.enabled ?? true,
   });
 }
 


### PR DESCRIPTION
## What

A legal representative (parent) viewing a child previously landed on the stripped-down `RepresentedPartyAccountPage`, which had no pension sections — so a child's **third pillar (III sammas)** was invisible. This adds the child's third-pillar holdings to that view.

## How

- `RepresentedPartyAccountPage.tsx` — renders a **read-only** third-pillar section (heading + holdings table) when the represented party is a person (`role.type === 'PERSON'`) and has pillar-3 funds. Companies (`LEGAL_ENTITY`) are unaffected — they never have a third pillar.
- `apiHooks.ts` — `useSourceFunds` gains an optional `enabled` flag so the pension-account-statement request only fires for a represented person, never for a company.
- Tests: child sees III pillar holdings, no II pillar leakage, company shows no third-pillar section.

## Scope decision: read-only

The section is intentionally read-only (no payment / fund-switch links). Making it interactive is deliberately **out of scope** here because:

- **Contribute (`/3rd-pillar-payment`)** — the payment flow builds the recipient from `user.personalCode`, which is always the logged-in *parent's* own code (the child lives only in `user.role.code`). Surfacing it as-is would credit the **parent's** third pillar, not the child's. Needs a `Payment.tsx` fix to target `role.code` **plus backend confirmation** that a parent can be payer while the child is recipient.
- **Change funds (`/3rd-pillar-flow`)** — mandate creation/signing is token/role-scoped so it would apply to the child, but the mandate embeds `state.login.user.address` (the parent's), and the flow has never been designed/tested for the represented case.

**Follow-up:** enable a parent to contribute to / re-select a child's third pillar (product sign-off + `Payment.tsx` recipient fix + mandate-address handling + backend verification + tests).

## Verification

- All 4 account test suites green (49 tests); `tsc --noEmit` clean; ESLint clean.

https://claude.ai/code/session_01BxCTDEwpEmaPBfZ7prH64r