### PR TITLE
Let the child flow pick multiple investment goals

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.test.tsx
@@ -33,7 +33,7 @@ const Wrapper = ({ defaultCode = '' }: { defaultCode?: string }) => {
       email: '',
       phoneNumber: '',
       pepSelfDeclaration: null,
-      investmentGoals: null,
+      investmentGoals: [],
       plannedContribution: null,
       fundingSources: [],
       termsAccepted: false,

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.test.tsx
@@ -18,7 +18,7 @@ const Wrapper = () => {
       email: '',
       phoneNumber: '',
       pepSelfDeclaration: null,
-      investmentGoals: null,
+      investmentGoals: [],
       plannedContribution: null,
       fundingSources: [],
       termsAccepted: false,

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.tsx
@@ -1,11 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
-import { Control, Controller, FieldPath, FieldValues, useWatch } from 'react-hook-form';
-import { FormattedMessage, useIntl } from 'react-intl';
-import type { FundingSourceOption, FundingSourcesSurveyItem } from '../types.api';
+import { Control, FieldPath, FieldValues } from 'react-hook-form';
+import type { FundingSourceOption } from '../types.api';
 import { TranslationKey } from '../../../../translations';
-import Checkbox from '../../../../common/checkbox/Checkbox';
-
-type FundingSourcesValue = FundingSourcesSurveyItem['value'];
+import { MultiSelectOptionsStep } from '../MultiSelectOptionsStep';
 
 type FundingSourcesStepProps<T extends FieldValues> = {
   control: Control<T>;
@@ -38,141 +34,19 @@ const OPTIONS: { id: string; value: FundingSourceOption; labelId: TranslationKey
 export const FundingSourcesStep = <T extends FieldValues>({
   control,
   name,
-}: FundingSourcesStepProps<T>) => {
-  const intl = useIntl();
-  const rawFundingSources = useWatch({ control, name });
-  const fundingSources: FundingSourcesValue = (rawFundingSources ?? []) as FundingSourcesValue;
-  const [isOtherSelected, setIsOtherSelected] = useState(
-    fundingSources.some((item) => item.type === 'TEXT'),
-  );
-  const [otherValue, setOtherValue] = useState(
-    fundingSources.find((item) => item.type === 'TEXT')?.value || '',
-  );
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (isOtherSelected) {
-      inputRef.current?.focus();
-    }
-  }, [isOtherSelected]);
-
-  const optionItems = () =>
-    fundingSources.filter((item) => item.type === 'OPTION') as Array<{
-      type: 'OPTION';
-      value: FundingSourceOption;
-    }>;
-
-  const handleCheckboxChange = (
-    fieldOnChange: (value: FundingSourcesValue) => void,
-    option: FundingSourceOption,
-    checked: boolean,
-  ) => {
-    const currentOptions = optionItems();
-    const currentTextItem = fundingSources.find((item) => item.type === 'TEXT');
-    const newOptions = checked
-      ? [...currentOptions, { type: 'OPTION' as const, value: option }]
-      : currentOptions.filter((item) => item.value !== option);
-    fieldOnChange(currentTextItem ? [...newOptions, currentTextItem] : newOptions);
-  };
-
-  const isChecked = (option: FundingSourceOption) =>
-    fundingSources.some((item) => item.type === 'OPTION' && item.value === option);
-
-  return (
-    <section className="d-flex flex-column gap-4" key="funding-sources">
-      <div className="d-flex flex-column gap-1">
-        <h2 className="m-0">
-          <FormattedMessage id="flows.savingsFundChildOnboarding.fundingSourcesStep.title" />
-        </h2>
-        <p className="m-0">
-          <FormattedMessage id="flows.savingsFundChildOnboarding.fundingSourcesStep.description" />
-        </p>
-      </div>
-      <div className="section-content d-flex flex-column gap-4">
-        <Controller
-          control={control}
-          name={name}
-          rules={{
-            validate: (raw) => {
-              const value: FundingSourcesValue = (raw ?? []) as FundingSourcesValue;
-              const hasOption = value.some((item) => item.type === 'OPTION');
-              const textItem = value.find((item) => item.type === 'TEXT');
-              const hasValidText = textItem && textItem.value.trim().length > 0;
-
-              if (!hasOption && !textItem) {
-                return intl.formatMessage({
-                  id: 'flows.savingsFundChildOnboarding.fundingSourcesStep.required',
-                });
-              }
-              if (textItem && !hasValidText) {
-                return intl.formatMessage({
-                  id: 'flows.savingsFundChildOnboarding.fundingSourcesStep.other.required',
-                });
-              }
-              return true;
-            },
-          }}
-          render={({ field, fieldState: { error } }) => {
-            const onChange = field.onChange as (value: FundingSourcesValue) => void;
-            return (
-              <div className="selection-group d-flex flex-column gap-2">
-                {OPTIONS.map(({ id, value, labelId }) => (
-                  <Checkbox
-                    key={id}
-                    id={id}
-                    checked={isChecked(value)}
-                    onToggle={(checked) => handleCheckboxChange(onChange, value, checked)}
-                  >
-                    <span className="fs-3 lh-sm">
-                      <FormattedMessage id={labelId} />
-                    </span>
-                  </Checkbox>
-                ))}
-                <div className="d-flex flex-column gap-2">
-                  <Checkbox
-                    id="funding-other"
-                    checked={isOtherSelected}
-                    onToggle={(checked) => {
-                      setIsOtherSelected(checked);
-                      if (checked) {
-                        onChange([...optionItems(), { type: 'TEXT', value: otherValue }]);
-                      } else {
-                        setOtherValue('');
-                        onChange(optionItems());
-                      }
-                    }}
-                  >
-                    <span className="fs-3 lh-sm" id="funding-other-label">
-                      <FormattedMessage id="flows.savingsFundChildOnboarding.fundingSourcesStep.other" />
-                    </span>
-                  </Checkbox>
-                  {isOtherSelected ? (
-                    <input
-                      ref={inputRef}
-                      type="text"
-                      className="form-control form-control-lg"
-                      aria-labelledby="funding-other-label"
-                      placeholder={intl.formatMessage({
-                        id: 'flows.savingsFundChildOnboarding.fundingSourcesStep.otherPlaceholder',
-                      })}
-                      value={otherValue}
-                      onChange={(e) => {
-                        setOtherValue(e.target.value);
-                        onChange([...optionItems(), { type: 'TEXT', value: e.target.value }]);
-                      }}
-                    />
-                  ) : null}
-                </div>
-                {error && error.message ? (
-                  <p className="m-0 text-danger fs-base" role="alert">
-                    {error.message}
-                  </p>
-                ) : null}
-              </div>
-            );
-          }}
-        />
-      </div>
-    </section>
-  );
-};
+}: FundingSourcesStepProps<T>) => (
+  <MultiSelectOptionsStep
+    control={control}
+    name={name}
+    options={OPTIONS}
+    titleId="flows.savingsFundChildOnboarding.fundingSourcesStep.title"
+    descriptionId="flows.savingsFundChildOnboarding.fundingSourcesStep.description"
+    otherId="funding-other"
+    messages={{
+      other: 'flows.savingsFundChildOnboarding.fundingSourcesStep.other',
+      otherPlaceholder: 'flows.savingsFundChildOnboarding.fundingSourcesStep.otherPlaceholder',
+      required: 'flows.savingsFundChildOnboarding.fundingSourcesStep.required',
+      otherRequired: 'flows.savingsFundChildOnboarding.fundingSourcesStep.other.required',
+    }}
+  />
+);

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/MultiSelectOptionsStep/MultiSelectOptionsStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/MultiSelectOptionsStep/MultiSelectOptionsStep.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from 'react';
+import { Control, Controller, FieldPath, FieldValues, useWatch } from 'react-hook-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { TranslationKey } from '../../../../translations';
+import Checkbox from '../../../../common/checkbox/Checkbox';
+
+type OptionItem<T extends string> = { type: 'OPTION'; value: T };
+type TextItem = { type: 'TEXT'; value: string };
+export type MultiSelectValue<T extends string> = Array<OptionItem<T> | TextItem>;
+
+type MultiSelectOptionsStepProps<F extends FieldValues, T extends string> = {
+  control: Control<F>;
+  name: FieldPath<F>;
+  options: { id: string; value: T; labelId: TranslationKey }[];
+  titleId: TranslationKey;
+  descriptionId: TranslationKey;
+  // Id of the "Other" checkbox; its label span gets `${otherId}-label` for aria-labelledby.
+  otherId: string;
+  messages: {
+    other: TranslationKey;
+    otherPlaceholder: TranslationKey;
+    required: TranslationKey;
+    otherRequired: TranslationKey;
+  };
+};
+
+// A multi-select step: card checkboxes over a list of options plus a free-text "Other".
+// The value is an array of {OPTION} / {TEXT} items. Shared by funding sources and the
+// child's investment goals — anywhere the saver may legitimately pick more than one.
+export const MultiSelectOptionsStep = <F extends FieldValues, T extends string>({
+  control,
+  name,
+  options,
+  titleId,
+  descriptionId,
+  otherId,
+  messages,
+}: MultiSelectOptionsStepProps<F, T>) => {
+  const intl = useIntl();
+  const otherLabelId = `${otherId}-label`;
+  const raw = useWatch({ control, name });
+  const selected: MultiSelectValue<T> = (raw ?? []) as MultiSelectValue<T>;
+  const [isOtherSelected, setIsOtherSelected] = useState(
+    selected.some((item) => item.type === 'TEXT'),
+  );
+  const [otherValue, setOtherValue] = useState(
+    selected.find((item) => item.type === 'TEXT')?.value || '',
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOtherSelected) {
+      inputRef.current?.focus();
+    }
+  }, [isOtherSelected]);
+
+  const optionItems = () =>
+    selected.filter((item): item is OptionItem<T> => item.type === 'OPTION');
+
+  const isChecked = (value: T) =>
+    selected.some((item) => item.type === 'OPTION' && item.value === value);
+
+  const handleToggle = (
+    onChange: (value: MultiSelectValue<T>) => void,
+    value: T,
+    checked: boolean,
+  ) => {
+    const currentOptions = optionItems();
+    const textItem = selected.find((item) => item.type === 'TEXT');
+    const newOptions = checked
+      ? [...currentOptions, { type: 'OPTION' as const, value }]
+      : currentOptions.filter((item) => item.value !== value);
+    onChange(textItem ? [...newOptions, textItem] : newOptions);
+  };
+
+  return (
+    <section className="d-flex flex-column gap-4" key={otherId}>
+      <div className="d-flex flex-column gap-1">
+        <h2 className="m-0">
+          <FormattedMessage id={titleId} />
+        </h2>
+        <p className="m-0">
+          <FormattedMessage id={descriptionId} />
+        </p>
+      </div>
+      <div className="section-content d-flex flex-column gap-4">
+        <Controller
+          control={control}
+          name={name}
+          rules={{
+            validate: (rawValue) => {
+              const value: MultiSelectValue<T> = (rawValue ?? []) as MultiSelectValue<T>;
+              const hasOption = value.some((item) => item.type === 'OPTION');
+              const textItem = value.find((item) => item.type === 'TEXT');
+              const hasValidText = textItem && textItem.value.trim().length > 0;
+
+              if (!hasOption && !textItem) {
+                return intl.formatMessage({ id: messages.required });
+              }
+              if (textItem && !hasValidText) {
+                return intl.formatMessage({ id: messages.otherRequired });
+              }
+              return true;
+            },
+          }}
+          render={({ field, fieldState: { error } }) => {
+            const onChange = field.onChange as (value: MultiSelectValue<T>) => void;
+            return (
+              <div className="selection-group d-flex flex-column gap-2">
+                {options.map(({ id, value, labelId }) => (
+                  <Checkbox
+                    key={id}
+                    id={id}
+                    checked={isChecked(value)}
+                    onToggle={(checked) => handleToggle(onChange, value, checked)}
+                  >
+                    <span className="fs-3 lh-sm">
+                      <FormattedMessage id={labelId} />
+                    </span>
+                  </Checkbox>
+                ))}
+                <div className="d-flex flex-column gap-2">
+                  <Checkbox
+                    id={otherId}
+                    checked={isOtherSelected}
+                    onToggle={(checked) => {
+                      setIsOtherSelected(checked);
+                      if (checked) {
+                        onChange([...optionItems(), { type: 'TEXT', value: otherValue }]);
+                      } else {
+                        setOtherValue('');
+                        onChange(optionItems());
+                      }
+                    }}
+                  >
+                    <span className="fs-3 lh-sm" id={otherLabelId}>
+                      <FormattedMessage id={messages.other} />
+                    </span>
+                  </Checkbox>
+                  {isOtherSelected ? (
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      className="form-control form-control-lg"
+                      aria-labelledby={otherLabelId}
+                      placeholder={intl.formatMessage({ id: messages.otherPlaceholder })}
+                      value={otherValue}
+                      onChange={(e) => {
+                        setOtherValue(e.target.value);
+                        onChange([...optionItems(), { type: 'TEXT', value: e.target.value }]);
+                      }}
+                    />
+                  ) : null}
+                </div>
+                {error && error.message ? (
+                  <p className="m-0 text-danger fs-base" role="alert">
+                    {error.message}
+                  </p>
+                ) : null}
+              </div>
+            );
+          }}
+        />
+      </div>
+    </section>
+  );
+};

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/MultiSelectOptionsStep/index.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/MultiSelectOptionsStep/index.ts
@@ -1,0 +1,2 @@
+export { MultiSelectOptionsStep } from './MultiSelectOptionsStep';
+export type { MultiSelectValue } from './MultiSelectOptionsStep';

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/PlannedContributionStep/PlannedContributionStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/PlannedContributionStep/PlannedContributionStep.test.tsx
@@ -18,7 +18,7 @@ const Wrapper = () => {
       email: '',
       phoneNumber: '',
       pepSelfDeclaration: null,
-      investmentGoals: null,
+      investmentGoals: [],
       plannedContribution: null,
       fundingSources: [],
       termsAccepted: false,

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -55,8 +55,8 @@ const advanceToTerms = async () => {
   expect(await screen.findByText('4/9')).toBeInTheDocument(); // contact (prefilled)
   userEvent.click(continueButton());
 
-  expect(await screen.findByText('5/9')).toBeInTheDocument(); // goal
-  userEvent.click(screen.getByRole('radio', { name: /Education/ }));
+  expect(await screen.findByText('5/9')).toBeInTheDocument(); // goal (multi-select)
+  userEvent.click(screen.getByRole('checkbox', { name: /Education/ }));
   userEvent.click(continueButton());
 
   expect(await screen.findByText('6/9')).toBeInTheDocument(); // contribution

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -8,7 +8,7 @@ import { ChildIdentityStep } from './ChildIdentityStep';
 import { ChildConfirmStep } from './ChildConfirmStep';
 import { ResidencyStep } from './ResidencyStep';
 import { ContactDetailsStep } from './ContactDetailsStep';
-import { InvestmentGoalStep } from './InvestmentGoalStep';
+import { MultiSelectOptionsStep } from './MultiSelectOptionsStep';
 import { PlannedContributionStep } from './PlannedContributionStep';
 import { InvestableAssetsStep } from './InvestableAssetsStep';
 import { FundingSourcesStep } from './FundingSourcesStep';
@@ -70,7 +70,7 @@ export const SavingsFundChildOnboarding = () => {
       email: '',
       phoneNumber: '',
       pepSelfDeclaration: null,
-      investmentGoals: null,
+      investmentGoals: [],
       plannedContribution: null,
       investableAssets: null,
       fundingSources: [],
@@ -140,17 +140,36 @@ export const SavingsFundChildOnboarding = () => {
     },
     {
       component: (
-        <InvestmentGoalStep
+        <MultiSelectOptionsStep
           key="goal"
           control={control}
           name="investmentGoals"
           titleId="flows.savingsFundChildOnboarding.goalStep.title"
           descriptionId="flows.savingsFundChildOnboarding.goalStep.description"
+          otherId="investment-goal-other"
           options={[
-            { value: 'CHILD', labelId: 'flows.savingsFundChildOnboarding.goalStep.general' },
-            { value: 'EDUCATION', labelId: 'flows.savingsFundChildOnboarding.goalStep.education' },
-            { value: 'FIRST_HOME', labelId: 'flows.savingsFundChildOnboarding.goalStep.firstHome' },
+            {
+              id: 'investment-goal-general',
+              value: 'CHILD',
+              labelId: 'flows.savingsFundChildOnboarding.goalStep.general',
+            },
+            {
+              id: 'investment-goal-education',
+              value: 'EDUCATION',
+              labelId: 'flows.savingsFundChildOnboarding.goalStep.education',
+            },
+            {
+              id: 'investment-goal-first-home',
+              value: 'FIRST_HOME',
+              labelId: 'flows.savingsFundChildOnboarding.goalStep.firstHome',
+            },
           ]}
+          messages={{
+            other: 'flows.savingsFundOnboarding.investmentGoalStep.other',
+            otherPlaceholder: 'flows.savingsFundOnboarding.investmentGoalStep.otherPlaceholder',
+            required: 'flows.savingsFundOnboarding.investmentGoalStep.required',
+            otherRequired: 'flows.savingsFundOnboarding.investmentGoalStep.other.required',
+          }}
         />
       ),
       fields: ['investmentGoals'],

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
@@ -122,7 +122,12 @@ type PepSelfDeclarationSurveyItem = {
 };
 type InvestmentGoalsSurveyItem = {
   type: 'INVESTMENT_GOALS';
-  value: OptionValue<InvestmentGoalOption> | TextValue;
+  // A single value (person/company flows) or an array (child flow, multi-select).
+  // The backend accepts both — a single value deserializes into a one-element list.
+  value:
+    | OptionValue<InvestmentGoalOption>
+    | TextValue
+    | (OptionValue<InvestmentGoalOption> | TextValue)[];
 };
 type InvestableAssetsSurveyItem = {
   type: 'INVESTABLE_ASSETS';

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/types.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/types.ts
@@ -15,6 +15,10 @@ export type InvestmentGoalsValue =
   | { type: 'OPTION'; value: InvestmentGoalOption }
   | { type: 'TEXT'; value: string };
 
+// The child flow lets a parent pick several goals at once (education and a first
+// home, say); the person and company flows stay single-select.
+export type InvestmentGoalsMultiValue = InvestmentGoalsValue[];
+
 export interface SharedOnboardingFields {
   termsAccepted: boolean;
 }
@@ -62,7 +66,7 @@ export interface ChildOnboardingFormData extends SharedOnboardingFields, Identit
   childPersonalCode: string;
   // Populated once POST /v1/me/children confirms custody (VERIFIED); null until then.
   child: VerifiedChild | null;
-  investmentGoals: InvestmentGoalsValue | null;
+  investmentGoals: InvestmentGoalsMultiValue;
   plannedContribution: PlannedContributionOption | null;
   investableAssets: InvestableAssetsOption | null;
   fundingSources: FundingSourcesValue;

--- a/src/components/flows/savingsAccount/utils.test.ts
+++ b/src/components/flows/savingsAccount/utils.test.ts
@@ -180,7 +180,7 @@ const buildChildFormData = (
   pepSelfDeclaration: null,
   childPersonalCode: '61509070000',
   child: { firstName: 'Mammu', lastName: 'Maasikas', dateOfBirth: '2015-09-07' },
-  investmentGoals: { type: 'OPTION', value: 'EDUCATION' },
+  investmentGoals: [{ type: 'OPTION', value: 'EDUCATION' }],
   plannedContribution: 'FROM_200_TO_600',
   investableAssets: 'UP_TO_2000',
   fundingSources: [{ type: 'OPTION', value: 'PARENT_INCOME_AND_SAVINGS' }],
@@ -208,6 +208,25 @@ describe('transformChildFormDataToSurveyCommand', () => {
       'INVESTABLE_ASSETS',
       'FUNDING_SOURCES',
     ]);
+  });
+
+  it('sends every chosen investment goal as an array', () => {
+    const { answers } = transformChildFormDataToSurveyCommand(
+      buildChildFormData({
+        investmentGoals: [
+          { type: 'OPTION', value: 'EDUCATION' },
+          { type: 'OPTION', value: 'FIRST_HOME' },
+        ],
+      }),
+    );
+
+    expect(answers).toContainEqual({
+      type: 'INVESTMENT_GOALS',
+      value: [
+        { type: 'OPTION', value: 'EDUCATION' },
+        { type: 'OPTION', value: 'FIRST_HOME' },
+      ],
+    });
   });
 
   it('never sends citizenship or PEP — both are derived backend-side, not by the parent', () => {
@@ -268,7 +287,7 @@ describe('transformChildFormDataToSurveyCommand', () => {
   it('omits goal, contribution, investable assets and funding sources when not provided', () => {
     const types = transformChildFormDataToSurveyCommand(
       buildChildFormData({
-        investmentGoals: null,
+        investmentGoals: [],
         plannedContribution: null,
         investableAssets: null,
         fundingSources: [],

--- a/src/components/flows/savingsAccount/utils.ts
+++ b/src/components/flows/savingsAccount/utils.ts
@@ -108,7 +108,7 @@ export const transformChildFormDataToSurveyCommand = (
     answers.push({ type: 'PHONE_NUMBER', value: { type: 'TEXT', value: data.phoneNumber } });
   }
 
-  if (data.investmentGoals) {
+  if (data.investmentGoals.length > 0) {
     answers.push({ type: 'INVESTMENT_GOALS', value: data.investmentGoals });
   }
 

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1424,7 +1424,7 @@
   "flows.savingsFundChildOnboarding.goalStep.general": "Generally for the child’s future",
   "flows.savingsFundChildOnboarding.goalStep.education": "Education",
   "flows.savingsFundChildOnboarding.goalStep.firstHome": "First home or its down payment",
-  "flows.savingsFundChildOnboarding.goalStep.description": "Choose the main goal for now",
+  "flows.savingsFundChildOnboarding.goalStep.description": "Choose all that apply",
   "flows.savingsFundChildOnboarding.contributionStep.title": "How much do you plan to save for your child?",
   "flows.savingsFundChildOnboarding.contributionStep.description": "Approximately — you can always change it.",
   "flows.savingsFundChildOnboarding.contributionStep.required": "Choose an amount",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1514,7 +1514,7 @@
   "flows.savingsFundChildOnboarding.goalStep.general": "Üldiselt lapse tuleviku tarbeks",
   "flows.savingsFundChildOnboarding.goalStep.education": "Haridus",
   "flows.savingsFundChildOnboarding.goalStep.firstHome": "Esimene kodu või selle sissemakse",
-  "flows.savingsFundChildOnboarding.goalStep.description": "Vali hetkel peamine eesmärk",
+  "flows.savingsFundChildOnboarding.goalStep.description": "Vali kõik sobivad",
   "flows.savingsFundChildOnboarding.contributionStep.title": "Kui palju plaanid lapsele koguda?",
   "flows.savingsFundChildOnboarding.contributionStep.description": "Ligikaudne — saad alati muuta.",
   "flows.savingsFundChildOnboarding.contributionStep.required": "Vali summa",


### PR DESCRIPTION
## What

A parent saving for a child may have more than one reason (education **and** a first home). This makes the **child flow's** investment-goal step multi-select. The person and company flows keep their single-select radio — untouched.

## How

Extracted the funding-sources multi-select-with-Other pattern into a shared **`MultiSelectOptionsStep`** (card checkboxes + free-text Other, array value) and pointed **both** funding sources and the child's goals at it — so there's no duplicate component. FundingSourcesStep shrank to a thin wrapper (−164 lines).

- Child `investmentGoals` field → array; submitted as an array.
- `InvestmentGoalsSurveyItem.value` now accepts a single value **or** an array.
- Backend accepts both shapes (**onboarding-service #1786**); a single value still deserializes into a one-element list, so live person/company payloads are unaffected.

## Stacked

Based on **#1595** (needs the `Checkbox` card from that PR). Base is `tkf-child-dropdown-names`; retarget to `master` once #1595 lands.

## Tests

- New: child submits every chosen goal as an array (`utils.test`).
- FundingSourcesStep tests pass unchanged (same rendered markup after the refactor); adult `InvestmentGoalStep` untouched and green.
- 165 tests across the touched suites green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)