### PR TITLE
Show profit in the company/child account view

### DIFF
--- a/src/components/account/AccountStatement/AccountStatement.tsx
+++ b/src/components/account/AccountStatement/AccountStatement.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { sortBy } from 'lodash';
+import { sortBy, sumBy } from 'lodash';
 import Table from '../../common/table';
 import { Euro } from '../../common/Euro';
 import { getValueSum, getWeightedAverageFee } from './fundSelector';
@@ -11,9 +11,10 @@ import { TableColumn } from '../../common/table/Table';
 
 interface Props {
   funds?: SourceFund[];
+  showProfit?: boolean;
 }
 
-const AccountStatement: React.FC<Props> = ({ funds }) => {
+const AccountStatement: React.FC<Props> = ({ funds, showProfit = false }) => {
   const { formatMessage } = useIntl();
 
   if (!funds) {
@@ -27,6 +28,8 @@ const AccountStatement: React.FC<Props> = ({ funds }) => {
   const valueSum = getValueSum(funds);
 
   const weightedAverageFee = valueSum <= 0 ? 0 : getWeightedAverageFee(funds);
+
+  const profitSum = showProfit ? sumBy(funds, (fund) => fund.profit) : 0;
 
   const columns: TableColumn[] = [
     {
@@ -63,6 +66,16 @@ const AccountStatement: React.FC<Props> = ({ funds }) => {
             hideOnBreakpoint: ['xs'],
           },
         ] as TableColumn[])),
+    ...(showProfit
+      ? ([
+          {
+            title: <FormattedMessage id="accountStatement.columns.profit.title" />,
+            dataIndex: 'profit',
+            width: 15,
+            footer: <Euro amount={profitSum} />,
+          },
+        ] as TableColumn[])
+      : []),
     {
       title: <FormattedMessage id="accountStatement.columns.value.title" />,
       dataIndex: 'value',
@@ -95,6 +108,7 @@ const AccountStatement: React.FC<Props> = ({ funds }) => {
       ),
       feesPercent: <Fees value={fund.ongoingChargesFigure} />,
       feesEuro: !feesEuro ? <></> : <Euro className="text-body-secondary" amount={feesEuro} />,
+      ...(showProfit ? { profit: <Euro amount={fund.profit} /> } : {}),
       value: <Euro amount={fundValue} />,
       key: fund.isin,
     };

--- a/src/components/account/PersonAccountPage.jsx
+++ b/src/components/account/PersonAccountPage.jsx
@@ -213,7 +213,7 @@ export function PersonAccountPage(
               </>
             </div>
           </SectionHeading>
-          <AccountStatement funds={[savingsFundBalance]} showProfit />
+          <AccountStatement funds={[savingsFundBalance]} />
         </>
       )}
 

--- a/src/components/account/PersonAccountPage.jsx
+++ b/src/components/account/PersonAccountPage.jsx
@@ -213,7 +213,7 @@ export function PersonAccountPage(
               </>
             </div>
           </SectionHeading>
-          <AccountStatement funds={[savingsFundBalance]} />
+          <AccountStatement funds={[savingsFundBalance]} showProfit />
         </>
       )}
 

--- a/src/components/account/RepresentedPartyAccountPage.test.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.test.tsx
@@ -68,6 +68,12 @@ describe('RepresentedPartyAccountPage', () => {
     );
   });
 
+  test('shows the savings fund profit next to its balance', async () => {
+    expect(await screen.findByText(additionalSavingsFund.fund.name)).toBeInTheDocument();
+    // The savings fund row now includes a profit ("Tulu") cell alongside the balance.
+    expect(await screen.findByText(/^500\.00\s€$/)).toBeInTheDocument();
+  });
+
   test('renders last transactions with link to savings fund transactions', async () => {
     expect(
       await screen.findByRole('heading', { name: 'Your latest transactions', level: 2 }),
@@ -154,7 +160,8 @@ describe('RepresentedPartyAccountPage with zero balance', () => {
     expect(
       await screen.findByText(new RegExp(additionalSavingsFund.fund.name)),
     ).toBeInTheDocument();
-    expect(screen.getByText(/0.00\s€/)).toBeInTheDocument();
+    // Profit and value cells both render 0.00 € for a zero-balance fund.
+    expect(screen.getAllByText(/0.00\s€/)).toHaveLength(2);
     expect(screen.getByRole('link', { name: 'Deposit' })).toHaveAttribute(
       'href',
       '/savings-fund/payment',

--- a/src/components/account/RepresentedPartyAccountPage.test.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.test.tsx
@@ -115,6 +115,12 @@ describe('RepresentedPartyAccountPage for a represented child', () => {
     expect(screen.getByText('Tuleva III Samba Pensionifond')).toBeInTheDocument();
   });
 
+  test("shows the child's third pillar profit (no summary table on this page)", async () => {
+    expect(await screen.findByText('Tuleva III Samba Pensionifond')).toBeInTheDocument();
+    // The child/company page has no account summary, so profit is shown in the detail table.
+    expect(screen.getByText(/1\s876\.54\s€/)).toBeInTheDocument();
+  });
+
   test('does not show second pillar funds for the child', async () => {
     expect(
       await screen.findByRole('heading', { name: /III\spillar/, level: 3 }),

--- a/src/components/account/RepresentedPartyAccountPage.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.tsx
@@ -50,7 +50,7 @@ export function RepresentedPartyAccountPage() {
           </Link>
         </div>
       </SectionHeading>
-      <AccountStatement funds={savingsFunds} />
+      <AccountStatement funds={savingsFunds} showProfit />
 
       <ApplicationSection />
 

--- a/src/components/account/RepresentedPartyAccountPage.tsx
+++ b/src/components/account/RepresentedPartyAccountPage.tsx
@@ -36,7 +36,7 @@ export function RepresentedPartyAccountPage() {
       {showThirdPillar && (
         <>
           <SectionHeading titleId="accountStatement.thirdPillar.heading" />
-          <AccountStatement funds={thirdPillarFunds} />
+          <AccountStatement funds={thirdPillarFunds} showProfit />
         </>
       )}
 


### PR DESCRIPTION
## Why

A **represented company or child** has **no account-summary table** ("Sinu vara koondseis") — that table exists only on a person's own account page. So for a company (which holds only the Täiendav Kogumisfond) or a child (III pillar), the **gain was not visible anywhere**. The personal view already shows profit in its summary, so it needs nothing.

## What

- `AccountStatement` gets an optional `showProfit` prop that inserts a **Tulu** column (before *Osakute väärtus*) rendering the per-fund `profit`.
- Enabled on **`RepresentedPartyAccountPage`** for **both** the third-pillar and savings-fund detail tables → a company sees its TKF gain, a parent sees the child's III-pillar and TKF gain.
- **`PersonAccountPage` is unchanged** — its summary already shows profit; adding it to the detail tables would only duplicate it and leave the II/III detail tables inconsistent.
- Reuses the existing i18n key `accountStatement.columns.profit.title` (`Tulu`/`Profit`) and the `profit` field that both `/v1/savings-account-statement` and `/v1/pension-account-statement` already return (mapped by the shared `transformFundBalance`). **No backend or API change.**

## Deliberate choices

- **Cumulative euro amount, not an annualized %.** TKF launched in 2026 (<1 yr of NAV history); an annualized IRR/XIRR would extrapolate a partial-year return, which GIPS 2.A.12 / ESMA marketing guidelines say must not be done for sub-year periods. The plain euro gain matches how `AccountSummary` already shows profit. A % / benchmark can follow once there is ≥1 yr of history.
- Profit shown only where there is no summary (company/child), so nothing is duplicated.
- Negative profit renders with a minus (like fees); no special colour, matching `<Euro>`.

## Tests

- `RepresentedPartyAccountPage.test.tsx`: company TKF profit shown; child III-pillar profit shown; zero-balance table updated for the extra cell.
- `lint` ✓ · `tsc --noEmit` ✓ · affected suites ✓ (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)