### PR TITLE
Update login-page privacy policy link to 16.07.2026 version

### DIFF
--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -21,7 +21,7 @@
   "login.join.tuleva": "Join!",
   "login.or": "or",
   "login.permission.note": "By logging in, you allow a one-time request for your data from the pension register and agree to Tuleva’s <a>privacy policy</a>.",
-  "login.permission.note.url": "https://tuleva.ee/en/tuleva-privacy-policy-and-terms-of-use-of-website/",
+  "login.permission.note.url": "https://tuleva.ee/privaatsuspoliitika-ja-veebilehe-kasutustingimused_16072026/",
   "login.not.member": "You aren’t a member of Tuleva yet?",
   "login.apply.link": "Fill out a membership application",
   "login.epis_maintenance": "Accessing your pension account may not be possible right now due to scheduled maintenance at Pensionikeskus.",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -21,7 +21,7 @@
   "login.join.tuleva": "Liitu!",
   "login.or": "või",
   "login.permission.note": "Sisenedes annad ühekordse loa küsida pensioniregistrist su andmed ja oled teadlik Tuleva <a>privaatsuspoliitikast</a>.",
-  "login.permission.note.url": "https://tuleva.ee/privaatsuspoliitika-ja-veebilehe-kasutustingimused/",
+  "login.permission.note.url": "https://tuleva.ee/privaatsuspoliitika-ja-veebilehe-kasutustingimused_16072026/",
   "login.not.member": "Sa pole veel Tuleva liige?",
   "login.apply.link": "Täida liitumisavaldus",
   "login.epis_maintenance": "Pensionikontole sisenemine ei pruugi olla praegu võimalik, sest Pensionikeskuse töös on planeeritud katkestus.",


### PR DESCRIPTION
## What
Updates the privacy-policy link shown in the login-page permission note (`login.permission.note.url`) to point to the new policy effective **16.07.2026**:
`https://tuleva.ee/privaatsuspoliitika-ja-veebilehe-kasutustingimused_16072026/`

Changed in both `translations.et.json` and `translations.en.json`.

## Why
The new policy is a **new page with a date-stamped slug**. The old slug (`.../privaatsuspoliitika-ja-veebilehe-kasutustingimused/`) still serves the outdated **21.10.2024** version and does *not* redirect, so the login page was linking users to a stale policy.

## English link
No English translation of the new policy exists yet (the English page still shows the 2024 version; the `_16072026` English slug is a 404). Per product decision, the English link points to the same Estonian page for now — to be repointed when an English version is published.

## Out of scope (not code)
The site-wide **WordPress footer** link is served from a WP database widget (`footer_bottom_widget_area`), not the theme repo, so it is changed in WP admin (Appearance → Widgets), not in this PR.

## Testing
- Both JSON files validated as parseable.
- Target URL returns HTTP 200 (live, published).
- Link is rendered via the existing `login.permission.note` / `login.permission.note.url` message pair on the login screen — no component changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)