### PR TITLE
Surface Coop partner-flow payment errors instead of failing silently

### DIFF
--- a/src/components/TriggerProcedure/utils.test.ts
+++ b/src/components/TriggerProcedure/utils.test.ts
@@ -44,4 +44,41 @@ describe('finish', () => {
       /COOP_WEB.*missing url/,
     );
   });
+
+  it('posts an error message to the partner app even when not authenticated', async () => {
+    const postMessage = jest.fn();
+    (window as unknown as { ReactNativeWebView: unknown }).ReactNativeWebView = { postMessage };
+    (getAuthentication as jest.Mock).mockReturnValue({ isAuthenticated: () => false });
+
+    await finish(undefined, 'handover failed');
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(postMessage.mock.calls[0][0])).toEqual({
+      errorMessage: 'handover failed',
+      time: expect.any(String),
+    });
+  });
+
+  it('rejects when personal code is missing instead of failing silently', async () => {
+    (window as unknown as { ReactNativeWebView: unknown }).ReactNativeWebView = {
+      postMessage: jest.fn(),
+    };
+    (getPaymentLink as jest.Mock).mockClear();
+
+    await expect(finish('newRecurringPayment', undefined, undefined)).rejects.toThrow(
+      /personal code/,
+    );
+    expect(getPaymentLink).not.toHaveBeenCalled();
+  });
+
+  it('rejects when provider is missing instead of failing silently', async () => {
+    sessionStorage.removeItem(PROVIDER_KEY);
+    (window as unknown as { ReactNativeWebView: unknown }).ReactNativeWebView = {
+      postMessage: jest.fn(),
+    };
+
+    await expect(finish('newRecurringPayment', undefined, '38812121215')).rejects.toThrow(
+      /provider/,
+    );
+  });
 });

--- a/src/components/TriggerProcedure/utils.test.ts
+++ b/src/components/TriggerProcedure/utils.test.ts
@@ -1,16 +1,18 @@
-import { finish, EXTERNAL_AUTHENTICATOR_REDIRECT_URI } from './utils';
+import {
+  finish,
+  EXTERNAL_AUTHENTICATOR_PROVIDER,
+  EXTERNAL_AUTHENTICATOR_REDIRECT_URI,
+} from './utils';
 import { getPaymentLink } from '../common/api';
 import { getAuthentication } from '../common/authenticationManager';
 
 jest.mock('../common/api');
 jest.mock('../common/authenticationManager');
 
-const PROVIDER_KEY = 'EXTERNAL_AUTHENTICATOR_PROVIDER';
-
 describe('finish', () => {
   beforeEach(() => {
     sessionStorage.clear();
-    sessionStorage.setItem(PROVIDER_KEY, 'COOP_PANK');
+    sessionStorage.setItem(EXTERNAL_AUTHENTICATOR_PROVIDER, 'COOP_PANK');
     sessionStorage.setItem(EXTERNAL_AUTHENTICATOR_REDIRECT_URI, 'https://partner.example/');
     (getAuthentication as jest.Mock).mockReturnValue({ isAuthenticated: () => true });
     delete (window as unknown as { ReactNativeWebView?: unknown }).ReactNativeWebView;
@@ -72,7 +74,7 @@ describe('finish', () => {
   });
 
   it('rejects when provider is missing instead of failing silently', async () => {
-    sessionStorage.removeItem(PROVIDER_KEY);
+    sessionStorage.removeItem(EXTERNAL_AUTHENTICATOR_PROVIDER);
     (window as unknown as { ReactNativeWebView: unknown }).ReactNativeWebView = {
       postMessage: jest.fn(),
     };

--- a/src/components/TriggerProcedure/utils.ts
+++ b/src/components/TriggerProcedure/utils.ts
@@ -62,30 +62,30 @@ const getPath = (provider: ExternalProvider, procedure: Procedure): string => {
   throw new Error(`Invalid procedure for provider(${provider}): ${procedure}`);
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any -- WIP
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const finish = async (result?: string, error?: string, personalCode?: string) => {
   const provider = sessionStorage.getItem(EXTERNAL_AUTHENTICATOR_PROVIDER);
   const redirectUri = sessionStorage.getItem(EXTERNAL_AUTHENTICATOR_REDIRECT_URI);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const webView = (window as any).ReactNativeWebView;
 
-  if (!provider) {
-    // eslint-disable-next-line no-console -- WIP
-    console.error('unexpected state: no provider');
+  if (webView && error) {
+    sendMessage({ errorMessage: error, time: new Date().toISOString() });
+  }
+  if (!result) {
     return;
   }
+
+  if (!provider) {
+    throw new Error('unexpected state: no provider');
+  }
   if (!getAuthentication().isAuthenticated() || !personalCode) {
-    // eslint-disable-next-line no-console -- WIP
-    console.error('unexpected state: no token/personal code');
-    return;
+    throw new Error('unexpected state: no token/personal code');
   }
 
   const paymentType = result === 'newRecurringPayment' ? 'RECURRING' : 'SINGLE';
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((window as any).ReactNativeWebView) {
-    if (error) {
-      sendMessage({ errorMessage: error, time: new Date().toISOString() });
-    }
-
+  if (webView) {
     const paymentLink = await getPaymentLink({
       type: paymentType,
       paymentChannel: 'PARTNER',

--- a/src/components/TriggerProcedure/utils.ts
+++ b/src/components/TriggerProcedure/utils.ts
@@ -1,7 +1,7 @@
 import { getPaymentLink } from '../common/api';
 import { getAuthentication } from '../common/authenticationManager';
 
-const EXTERNAL_AUTHENTICATOR_PROVIDER = 'EXTERNAL_AUTHENTICATOR_PROVIDER';
+export const EXTERNAL_AUTHENTICATOR_PROVIDER = 'EXTERNAL_AUTHENTICATOR_PROVIDER';
 export const EXTERNAL_AUTHENTICATOR_REDIRECT_URI = 'EXTERNAL_AUTHENTICATOR_REDIRECT_URI';
 
 enum ExternalProvider {
@@ -62,8 +62,11 @@ const getPath = (provider: ExternalProvider, procedure: Procedure): string => {
   throw new Error(`Invalid procedure for provider(${provider}): ${procedure}`);
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const finish = async (result?: string, error?: string, personalCode?: string) => {
+export const finish = async (
+  result?: string,
+  error?: string,
+  personalCode?: string,
+): Promise<void> => {
   const provider = sessionStorage.getItem(EXTERNAL_AUTHENTICATOR_PROVIDER);
   const redirectUri = sessionStorage.getItem(EXTERNAL_AUTHENTICATOR_REDIRECT_URI);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/flows/partner/BackToPartner/BackToPartner.spec.tsx
+++ b/src/components/flows/partner/BackToPartner/BackToPartner.spec.tsx
@@ -18,6 +18,7 @@ import {
   userConversionBackend,
 } from '../../../../test/backend';
 import LoggedInApp from '../../../LoggedInApp';
+import { EXTERNAL_AUTHENTICATOR_PROVIDER } from '../../../TriggerProcedure/utils';
 
 describe('When is at the partner flow success screen', () => {
   const server = setupServer();
@@ -48,7 +49,7 @@ describe('When is at the partner flow success screen', () => {
 
   beforeEach(async () => {
     initializeConfiguration();
-    sessionStorage.setItem('EXTERNAL_AUTHENTICATOR_PROVIDER', 'COOP_PANK');
+    sessionStorage.setItem(EXTERNAL_AUTHENTICATOR_PROVIDER, 'COOP_PANK');
 
     userConversionBackend(server);
     userBackend(server);

--- a/src/components/flows/partner/BackToPartner/BackToPartner.spec.tsx
+++ b/src/components/flows/partner/BackToPartner/BackToPartner.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Route } from 'react-router-dom';
 import { createMemoryHistory, History } from 'history';
 import { createDefaultStore, login, renderWrapped } from '../../../../test/utils';
@@ -37,11 +39,16 @@ describe('When is at the partner flow success screen', () => {
   }
 
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-  afterEach(() => server.resetHandlers());
+  afterEach(() => {
+    server.resetHandlers();
+    sessionStorage.clear();
+    delete (window as unknown as { ReactNativeWebView?: unknown }).ReactNativeWebView;
+  });
   afterAll(() => server.close());
 
   beforeEach(async () => {
     initializeConfiguration();
+    sessionStorage.setItem('EXTERNAL_AUTHENTICATOR_PROVIDER', 'COOP_PANK');
 
     userConversionBackend(server);
     userBackend(server);
@@ -63,12 +70,63 @@ describe('When is at the partner flow success screen', () => {
 
   test('recurring payment button is shown', async () => {
     const button = await recurringPaymentButton();
-    expect(button).toBeEnabled();
+    await waitFor(() => expect(button).toBeEnabled());
   });
 
   test('single payment button is shown', async () => {
     const button = await singlePaymentButton();
-    expect(button).toBeEnabled();
+    await waitFor(() => expect(button).toBeEnabled());
+  });
+
+  test('recurring payment button posts the payment link to the partner app without an amount', async () => {
+    const postMessage = jest.fn();
+    (window as unknown as { ReactNativeWebView: unknown }).ReactNativeWebView = { postMessage };
+    server.use(
+      rest.get('http://localhost/v1/payments/link', (req, res, ctx) => {
+        if (
+          req.url.searchParams.get('amount') !== null ||
+          req.url.searchParams.get('paymentChannel') !== 'PARTNER' ||
+          req.url.searchParams.get('type') !== 'RECURRING'
+        ) {
+          return res(ctx.status(400), ctx.json({ errors: [{ code: 'payment.amount.required' }] }));
+        }
+        return res(
+          ctx.json({
+            type: 'PREFILLED',
+            url: JSON.stringify({ accountNumber: 'EE362200221067235244', interval: 'MONTHLY' }),
+          }),
+        );
+      }),
+    );
+
+    const button = await recurringPaymentButton();
+    await waitFor(() => expect(button).toBeEnabled());
+    userEvent.click(button);
+
+    await waitFor(() => expect(postMessage).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(postMessage.mock.calls[0][0])).toEqual({
+      type: 'newRecurringPayment',
+      version: '1',
+      data: { accountNumber: 'EE362200221067235244', interval: 'MONTHLY' },
+      time: expect.any(String),
+    });
+  });
+
+  test('shows an error when the payment link cannot be fetched', async () => {
+    server.use(
+      rest.get('http://localhost/v1/payments/link', (req, res, ctx) =>
+        res(ctx.status(400), ctx.json({ errors: [{ code: 'payment.amount.required' }] })),
+      ),
+    );
+
+    const button = await recurringPaymentButton();
+    await waitFor(() => expect(button).toBeEnabled());
+    userEvent.click(button);
+
+    expect(
+      await screen.findByText('An unexpected error occurred while initiating process'),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(button).toBeEnabled());
   });
 
   const recurringPaymentButton = async () =>

--- a/src/components/flows/partner/BackToPartner/BackToPartner.tsx
+++ b/src/components/flows/partner/BackToPartner/BackToPartner.tsx
@@ -13,7 +13,25 @@ interface Props {
 }
 
 export const BackToPartner: React.FC<Props> = ({ recurringPaymentCount }) => {
-  const personalCode = useSelector<State, string>((state) => state.login.user?.personalCode);
+  const personalCode = useSelector<State, string | undefined>(
+    (state) => state.login.user?.personalCode,
+  );
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState(false);
+
+  const finishWith = async (result: string) => {
+    setError(false);
+    setSubmitting(true);
+    try {
+      await finishProcedure(result, undefined, personalCode);
+    } catch (err) {
+      // eslint-disable-next-line no-console -- make this flow more debuggable for 3rd parties
+      console.error('error on finish', err);
+      setError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <>
@@ -56,7 +74,8 @@ export const BackToPartner: React.FC<Props> = ({ recurringPaymentCount }) => {
             <button
               type="button"
               className="btn btn-primary btn-default flex-grow-1 flex-md-grow-0"
-              onClick={() => finishProcedure('newRecurringPayment', undefined, personalCode)}
+              disabled={!personalCode || submitting}
+              onClick={() => finishWith('newRecurringPayment')}
             >
               <FormattedMessage id="thirdPillarBackToPartner.recurringPayment.button" />
             </button>
@@ -68,11 +87,17 @@ export const BackToPartner: React.FC<Props> = ({ recurringPaymentCount }) => {
           <button
             type="button"
             className="btn btn-outline-primary flex-grow-1 flex-md-grow-0"
-            onClick={() => finishProcedure('newPayment', undefined, personalCode)}
+            disabled={!personalCode || submitting}
+            onClick={() => finishWith('newPayment')}
           >
             <FormattedMessage id="thirdPillarBackToPartner.singlePayment.button" />
           </button>
         </div>
+        {error && (
+          <p className="text-danger mt-2 mb-0">
+            <FormattedMessage id="partnerFlow.error" />
+          </p>
+        )}
         <p className="mt-2 mb-0">
           <small className="text-body-secondary">
             <FormattedMessage id="thirdPillarBackToPartner.payment.subtitle" />


### PR DESCRIPTION
Companion to TulevaEE/onboarding-service#1790. The 'Seadista igakuine püsimakse' button in the Coop partner flow did nothing when clicked: the payment-link request 400s (missing amount, fixed in the backend PR) and finish() swallowed every failure — silent guard returns and unhandled promise rejections with zero UI feedback.

Changes:
- finish() posts the errorMessage to the partner app before any guards (the error-reporting path was previously unreachable) and throws on missing provider/personal code instead of silently returning
- BackToPartner disables both payment buttons until personalCode has loaded, prevents double-submits, and shows the partnerFlow.error message when the payment link cannot be fetched
- New tests pin the postMessage contract (type newRecurringPayment, version 1, no amount sent) and the visible error state