### PR TITLE
Mark already onboarded children in the child picker

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.test.tsx
@@ -201,6 +201,25 @@ describe('ChildIdentityStep', () => {
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
     });
 
+    test('marks an already onboarded child and prevents selecting them again', async () => {
+      eligibleChildrenBackend(server, [
+        {
+          personalCode: '61506150006',
+          firstName: 'Mari',
+          lastName: 'Maasikas',
+          hasBeenOnboarded: true,
+        },
+        { personalCode: '61001010000' },
+      ]);
+      renderWrapped(<Wrapper />);
+
+      const onboardedOption = await screen.findByRole('option', {
+        name: 'Mari Maasikas (61506150006) — account already opened',
+      });
+      expect(onboardedOption).toBeDisabled();
+      expect(screen.getByRole('option', { name: '61001010000' })).toBeEnabled();
+    });
+
     test('falls back to manual entry when the child is not listed', async () => {
       renderWrapped(<Wrapper />);
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.tsx
@@ -69,14 +69,25 @@ export const ChildIdentityStep: FC<ChildIdentityStepProps> = ({ control }) => {
                         id: 'flows.savingsFundChildOnboarding.identityStep.selectPlaceholder',
                       })}
                     </option>
-                    {eligibleChildren.map(({ personalCode, firstName, lastName }) => {
-                      const name = [firstName, lastName].filter(Boolean).join(' ');
-                      return (
-                        <option key={personalCode} value={personalCode}>
-                          {name ? `${name} (${personalCode})` : personalCode}
-                        </option>
-                      );
-                    })}
+                    {eligibleChildren.map(
+                      ({ personalCode, firstName, lastName, hasBeenOnboarded }) => {
+                        const name = [firstName, lastName].filter(Boolean).join(' ');
+                        const label = name ? `${name} (${personalCode})` : personalCode;
+                        return (
+                          <option
+                            key={personalCode}
+                            value={personalCode}
+                            disabled={hasBeenOnboarded}
+                          >
+                            {hasBeenOnboarded
+                              ? `${label} — ${intl.formatMessage({
+                                  id: 'flows.savingsFundChildOnboarding.identityStep.accountOpened',
+                                })}`
+                              : label}
+                          </option>
+                        );
+                      },
+                    )}
                   </select>
                 ) : (
                   <input

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
@@ -194,10 +194,13 @@ export type KycIdentity = {
 
 // GET /v1/me/children — children whose assets the parent may manage according
 // to the population register. The name comes from the register and may be absent.
+// hasBeenOnboarded means a savings fund onboarding already exists for the child
+// (opened by either parent); optional until the backend that sends it is deployed.
 export type EligibleChild = {
   personalCode: string;
   firstName?: string;
   lastName?: string;
+  hasBeenOnboarded?: boolean;
 };
 
 // POST /v1/me/children — the parent opens an account for their child. The custody

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1417,6 +1417,7 @@
   "flows.savingsFundChildOnboarding.identityStep.selectDescription": "We show the children whose assets you have the right to manage according to the population register — no documents to upload.",
   "flows.savingsFundChildOnboarding.identityStep.selectPlaceholder": "Select a child",
   "flows.savingsFundChildOnboarding.identityStep.enterManually": "Enter the personal ID code manually",
+  "flows.savingsFundChildOnboarding.identityStep.accountOpened": "account already opened",
   "flows.savingsFundChildOnboarding.confirmStep.title": "Child's details",
   "flows.savingsFundChildOnboarding.confirmStep.name": "Name",
   "flows.savingsFundChildOnboarding.confirmStep.dateOfBirth": "Date of birth",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1507,6 +1507,7 @@
   "flows.savingsFundChildOnboarding.identityStep.selectDescription": "Näitame lapsi, kelle vara sul on rahvastikuregistri järgi õigus hallata — dokumente pole vaja üles laadida.",
   "flows.savingsFundChildOnboarding.identityStep.selectPlaceholder": "Vali laps",
   "flows.savingsFundChildOnboarding.identityStep.enterManually": "Sisesta isikukood käsitsi",
+  "flows.savingsFundChildOnboarding.identityStep.accountOpened": "konto juba avatud",
   "flows.savingsFundChildOnboarding.confirmStep.title": "Lapse andmed",
   "flows.savingsFundChildOnboarding.confirmStep.name": "Nimi",
   "flows.savingsFundChildOnboarding.confirmStep.dateOfBirth": "Sünniaeg",

--- a/src/test/backend.ts
+++ b/src/test/backend.ts
@@ -987,7 +987,12 @@ export function savingsFundOnboardingSurveyBackend(
 
 export function eligibleChildrenBackend(
   server: SetupServerApi,
-  children: { personalCode: string; firstName?: string; lastName?: string }[] = [],
+  children: {
+    personalCode: string;
+    firstName?: string;
+    lastName?: string;
+    hasBeenOnboarded?: boolean;
+  }[] = [],
 ): void {
   server.use(
     rest.get('http://localhost/v1/me/children', (req, res, ctx) => res(ctx.json(children))),


### PR DESCRIPTION
GET /v1/me/children now sends hasBeenOnboarded for children who already have a savings fund onboarding. Their dropdown option is disabled and suffixed "konto juba avatud", so a parent can't start a duplicate onboarding for the same child.