### PR TITLE
Persist onboarding preview flag through login

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.test.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.test.ts
@@ -1,4 +1,5 @@
 import {
+  captureOnboardingPreviewFlags,
   getOnboardingFlowOptions,
   isChildOnboardingEnabled,
   isCompanyOnboardingEnabled,
@@ -45,6 +46,32 @@ describe('isChildOnboardingEnabled', () => {
     expect(isChildOnboardingEnabled()).toBe(true);
 
     window.history.pushState({}, '', '/?childOnboardingPreview=false');
+    expect(isChildOnboardingEnabled()).toBe(false);
+  });
+});
+
+describe('captureOnboardingPreviewFlags', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+    window.history.pushState({}, '', '/');
+  });
+
+  it('captures the child preview at boot so it survives the login round-trip', () => {
+    // Enter on a preview link (?childOnboardingPreview=true) while logged out —
+    // the app boots on that URL before redirecting to /login.
+    window.history.pushState({}, '', '/savings-fund/onboarding/child?childOnboardingPreview=true');
+    captureOnboardingPreviewFlags();
+
+    // After login the app redirects to the pathname only, dropping the query
+    // string. The flag must still be on because boot captured it.
+    window.history.pushState({}, '', '/savings-fund/onboarding/child');
+    expect(isChildOnboardingEnabled()).toBe(true);
+  });
+
+  it('leaves the child preview off when no preview parameter was present at boot', () => {
+    window.history.pushState({}, '', '/login');
+    captureOnboardingPreviewFlags();
+
     expect(isChildOnboardingEnabled()).toBe(false);
   });
 });

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.test.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.test.ts
@@ -56,19 +56,19 @@ describe('captureOnboardingPreviewFlags', () => {
     window.history.pushState({}, '', '/');
   });
 
-  it('captures the child preview at boot so it survives the login round-trip', () => {
-    // Enter on a preview link (?childOnboardingPreview=true) while logged out —
-    // the app boots on that URL before redirecting to /login.
-    window.history.pushState({}, '', '/savings-fund/onboarding/child?childOnboardingPreview=true');
+  it('persists the child preview so it survives the login round-trip', () => {
+    // A logged-out user enters on a preview link and is routed to /login with the
+    // query string preserved; the login page captures it before authenticating.
+    window.history.pushState({}, '', '/login?childOnboardingPreview=true');
     captureOnboardingPreviewFlags();
 
-    // After login the app redirects to the pathname only, dropping the query
-    // string. The flag must still be on because boot captured it.
+    // The post-login redirect keeps only the pathname, dropping the query string.
+    // The flag must still be on because it was captured before the redirect.
     window.history.pushState({}, '', '/savings-fund/onboarding/child');
     expect(isChildOnboardingEnabled()).toBe(true);
   });
 
-  it('leaves the child preview off when no preview parameter was present at boot', () => {
+  it('leaves the child preview off when no preview parameter is present', () => {
     window.history.pushState({}, '', '/login');
     captureOnboardingPreviewFlags();
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.ts
@@ -29,6 +29,17 @@ export const isCompanyOnboardingEnabled = (): boolean =>
 export const isChildOnboardingEnabled = (): boolean =>
   CHILD_ONBOARDING_LAUNCHED || isPreviewEnabled(CHILD_PREVIEW_SESSION_KEY);
 
+// Persist any ?<key>=true|false preview override into sessionStorage at app
+// boot. Without this the override is only captured when an onboarding gate
+// renders, which never happens on /login, and the post-login redirect keeps
+// only the pathname — so a preview link (e.g. a "for a child" landing page)
+// would lose its flag across login. Called once from the App constructor, so
+// it runs on every entry page including /login, mirroring the test-mode capture.
+export const captureOnboardingPreviewFlags = (): void => {
+  isPreviewEnabled(COMPANY_PREVIEW_SESSION_KEY);
+  isPreviewEnabled(CHILD_PREVIEW_SESSION_KEY);
+};
+
 export type OnboardingFlowOption = {
   key: 'person' | 'company' | 'child';
   route: string;

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows.ts
@@ -29,12 +29,12 @@ export const isCompanyOnboardingEnabled = (): boolean =>
 export const isChildOnboardingEnabled = (): boolean =>
   CHILD_ONBOARDING_LAUNCHED || isPreviewEnabled(CHILD_PREVIEW_SESSION_KEY);
 
-// Persist any ?<key>=true|false preview override into sessionStorage at app
-// boot. Without this the override is only captured when an onboarding gate
-// renders, which never happens on /login, and the post-login redirect keeps
-// only the pathname — so a preview link (e.g. a "for a child" landing page)
-// would lose its flag across login. Called once from the App constructor, so
-// it runs on every entry page including /login, mirroring the test-mode capture.
+// Persist any ?<key>=true|false preview override into sessionStorage. Otherwise
+// the override is only captured when an onboarding gate renders (via the *Enabled
+// helpers), which never happens on the login page, and the post-login redirect
+// keeps only the pathname — so a preview link (e.g. a "for a child" landing page)
+// that bounces a logged-out user through login would lose its flag. Called from
+// the login page so the flag is captured before the login round-trip.
 export const captureOnboardingPreviewFlags = (): void => {
   isPreviewEnabled(COMPANY_PREVIEW_SESSION_KEY);
   isPreviewEnabled(CHILD_PREVIEW_SESSION_KEY);

--- a/src/components/login/LoginPage.js
+++ b/src/components/login/LoginPage.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { PropTypes as Types } from 'prop-types';
 import { Redirect, withRouter } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 
 import { logo, AuthenticationLoader, ErrorAlert } from '../common';
 import { usePageTitle } from '../common/usePageTitle';
+import { captureOnboardingPreviewFlags } from '../flows/savingsAccount/SavingsFundOnboarding/onboardingFlows';
 import styles from './LoginPage.module.scss';
 import { loginPath } from './constants';
 
@@ -39,6 +40,13 @@ export const LoginPage = ({
   location,
 }) => {
   usePageTitle('pageTitle.loginPage');
+
+  // Capture any onboarding preview override (?childOnboardingPreview=true) from
+  // the entry URL now, so it survives the post-login redirect that keeps only
+  // the pathname. This is how a preview link enables the child flow through login.
+  useEffect(() => {
+    captureOnboardingPreviewFlags();
+  }, []);
 
   if (isAuthenticated) {
     return <Redirect to={location.state && location.state.from ? location.state.from : '/'} />;

--- a/src/components/login/LoginPage.preview.test.tsx
+++ b/src/components/login/LoginPage.preview.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+
+import { createDefaultStore, renderWrapped } from '../../test/utils';
+import { initializeConfiguration } from '../config/config';
+import { getAuthentication } from '../common/authenticationManager';
+import { isChildOnboardingEnabled } from '../flows/savingsAccount/SavingsFundOnboarding/onboardingFlows';
+// eslint-disable-next-line import/no-named-as-default
+import LoginPage, { loginPath } from './LoginPage';
+
+jest.unmock('react-intl');
+
+describe('When landing on the login page via an onboarding preview link', () => {
+  beforeEach(() => {
+    initializeConfiguration();
+    getAuthentication().remove();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    window.history.pushState({}, '', '/');
+  });
+
+  function renderLoginPage() {
+    const history = createMemoryHistory({ initialEntries: [loginPath] });
+    renderWrapped(
+      <Switch>
+        <Route exact path="/" render={() => <h1>Mock account page</h1>} />
+        <Route exact path={loginPath} component={LoginPage} />
+      </Switch>,
+      history as any,
+      createDefaultStore(history as any),
+    );
+  }
+
+  it('captures ?childOnboardingPreview=true so the child flow stays enabled after login', () => {
+    expect(isChildOnboardingEnabled()).toBe(false);
+
+    window.history.pushState({}, '', `${loginPath}?childOnboardingPreview=true`);
+    renderLoginPage();
+
+    // The post-login redirect keeps only the pathname, but the login page already
+    // captured the flag, so the child flow is enabled for the rest of the session.
+    window.history.pushState({}, '', '/savings-fund/onboarding/child');
+    expect(isChildOnboardingEnabled()).toBe(true);
+  });
+
+  it('does not enable the child flow without the preview parameter', () => {
+    window.history.pushState({}, '', loginPath);
+    renderLoginPage();
+
+    expect(isChildOnboardingEnabled()).toBe(false);
+  });
+});

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,7 +34,6 @@ import { loginPath } from './components/login/LoginPage';
 
 import { createTrackedEvent } from './components/common/api';
 import { shouldWriteTestMode, writeTestMode } from './components/common/test-mode';
-import { captureOnboardingPreviewFlags } from './components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows';
 
 const history = createBrowserHistory();
 
@@ -114,7 +113,6 @@ export class App extends Component {
   constructor(props) {
     applyRouting();
     applyTestModeForSession();
-    captureOnboardingPreviewFlags();
     super(props);
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,6 +34,7 @@ import { loginPath } from './components/login/LoginPage';
 
 import { createTrackedEvent } from './components/common/api';
 import { shouldWriteTestMode, writeTestMode } from './components/common/test-mode';
+import { captureOnboardingPreviewFlags } from './components/flows/savingsAccount/SavingsFundOnboarding/onboardingFlows';
 
 const history = createBrowserHistory();
 
@@ -113,6 +114,7 @@ export class App extends Component {
   constructor(props) {
     applyRouting();
     applyTestModeForSession();
+    captureOnboardingPreviewFlags();
     super(props);
   }
 


### PR DESCRIPTION
## What & why

Child onboarding is gated behind `?childOnboardingPreview=true`, which writes the flag to `sessionStorage`. The problem: that override is **only captured when an onboarding gate renders** (`isChildOnboardingEnabled()`), and nothing on `/login` renders one. Combined with the post-login redirect keeping only the pathname (`PrivateRoute` stores `state.from = pathname`, `LoginPage` redirects there, dropping the query string), a preview link that has to bounce a logged-out user through login loses its flag on the way in.

So today you can only reach child onboarding by appending the param **after** you're already logged in. This change makes it enable-on-entry: land on the app via a `?childOnboardingPreview=true` link (e.g. a "for a child" landing page's CTA), log in, and child onboarding is on for the session.

## Change

Capture the preview override into `sessionStorage` on the **login page** (`LoginPage`, a mount-time `useEffect`). For a logged-out user every entry path funnels through `/login` with the query string preserved, so the flag is captured before the post-login redirect drops it. The already-logged-in path is unchanged — the onboarding route gates still capture the param directly.

- `onboardingFlows.ts`: new `captureOnboardingPreviewFlags()` (captures both company + child keys).
- `LoginPage.js`: call it once on mount.
- Tests: `onboardingFlows.test.ts` covers the helper + login round-trip; `LoginPage.preview.test.tsx` asserts landing on `/login?childOnboardingPreview=true` keeps the child flow enabled after the redirect.

> Note: an earlier revision wired this into the `App` constructor in `index.jsx`; that left one uncovered patch line because the entry file is not unit-tested. Moving it to `LoginPage` is both better-tested and a more precise home ("the page you log in from").

## Safety

No change to default behaviour — the flag stays off unless the URL carries `?childOnboardingPreview=true`, and `=false` still clears it. It only reveals the launch UI; it grants nothing the backend doesn't already allow (backend gating for child onboarding is unchanged).

## Open question for reviewer

"A certain page" is any entry URL that carries `?childOnboardingPreview=true` — wire whichever landing/CTA link should open the child flow to that param. If instead you want a **bare** in-app route to auto-enable without the magic param, that's a different, less-gated change (and runs against the "stays hidden until the backend lands" intent) — flagging so we pick deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)