### PR TITLE
Skip the child selector when arriving from the account switcher

### DIFF
--- a/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.tsx
+++ b/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.tsx
@@ -18,10 +18,8 @@ const dropdownItemsOf = (container: HTMLElement | null): HTMLElement[] =>
 
 export const RoleSwitcher = ({ userName, onRoleSwitch }: Props) => {
   const { data: roles } = useRoles();
-  // Only fetch pending onboardings while the child flow is actually reachable —
-  // the /savings-fund/onboarding/child route redirects away until child
-  // onboarding is launched, so a menu item shown before then would be a dead
-  // link, and the header would fire the request for every user for nothing.
+  // The child route redirects away until child onboarding launches — no dead
+  // menu links, and the always-mounted header must not fetch for every user.
   const childOnboardingEnabled = isChildOnboardingEnabled();
   const { data: pendingOnboardings = [] } = usePendingOnboardings({
     enabled: childOnboardingEnabled,
@@ -99,10 +97,8 @@ export const RoleSwitcher = ({ userName, onRoleSwitch }: Props) => {
   const pendingChildOnboardings = pendingOnboardings.filter(({ type }) => type === 'PERSON');
   const hasPendingChildOnboardings = childOnboardingEnabled && pendingChildOnboardings.length > 0;
 
-  // Once company onboarding is live, even a single-role user gets the dropdown
-  // — it is the entry point for adding a company. A pending child (opened by the
-  // other parent) is likewise a reason to open the dropdown for a single-role
-  // user, so they can join that child's onboarding.
+  // Even a single-role user gets the dropdown when there is something to add:
+  // a company to onboard, or a pending child to join.
   if (!roles || (roles.length <= 1 && !companyOnboardingEnabled && !hasPendingChildOnboardings)) {
     return <span className="text-body">{displayName}</span>;
   }
@@ -155,8 +151,7 @@ export const RoleSwitcher = ({ userName, onRoleSwitch }: Props) => {
               <Link
                 key={code}
                 className="dropdown-item"
-                // The minor's personal code travels in router state only — never the
-                // URL/query — so it stays out of history, logs, and the address bar.
+                // Router state, never the URL: the minor's code must stay out of history and logs.
                 to={{
                   pathname: '/savings-fund/onboarding/child',
                   state: { childPersonalCode: code },

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.tsx
@@ -13,22 +13,15 @@ export const ChildIdentityStep: FC<ChildIdentityStepProps> = ({ control }) => {
   const intl = useIntl();
   const { data: eligibleChildren = [], isLoading } = useEligibleChildren();
   const { data: pendingOnboardings = [] } = usePendingOnboardings();
-  // Children the other guardian already onboarded stay selectable for this user:
-  // joining them (completing their own custody-verified onboarding) is exactly
-  // what a pending onboarding entry invites them to do.
   const joinableChildCodes = new Set(
     pendingOnboardings.filter(({ type }) => type === 'PERSON').map(({ code }) => code),
   );
   const [manualEntry, setManualEntry] = useState(false);
   const childPersonalCode = useWatch({ control, name: 'childPersonalCode' });
-  // A code typed while the lookup was in flight, or carried over from an earlier
-  // manual entry, keeps the free-text input — the dropdown must never hide or
-  // replace a value that isn't one of its options.
-  const showDropdown =
-    !manualEntry &&
-    eligibleChildren.length > 0 &&
-    (!childPersonalCode ||
-      eligibleChildren.some(({ personalCode }) => personalCode === childPersonalCode));
+  const enteredCodeIsSelectable =
+    !childPersonalCode ||
+    eligibleChildren.some(({ personalCode }) => personalCode === childPersonalCode);
+  const showDropdown = !manualEntry && eligibleChildren.length > 0 && enteredCodeIsSelectable;
 
   return (
     <section className="d-flex flex-column gap-4" key="child-identity">
@@ -98,9 +91,7 @@ export const ChildIdentityStep: FC<ChildIdentityStepProps> = ({ control }) => {
                   <input
                     {...field}
                     id={field.name}
-                    // Disabled until the children lookup settles: if the control could be
-                    // focused now, its swap to a select would silently steal focus. Choosing
-                    // manual entry pins the input, so it is safe to enable mid-lookup.
+                    // A focused input swapped for the select would silently steal focus.
                     disabled={isLoading && !manualEntry}
                     inputMode="numeric"
                     autoComplete="off"

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -136,6 +136,73 @@ describe('SavingsFundChildOnboarding', () => {
     ).toBeInTheDocument();
   });
 
+  it('clears everything entered for the previous child when a different child is picked', async () => {
+    const OTHER_CHILD_CODE = '61001010000';
+    createChildBackend(server);
+    const history = createMemoryHistory({
+      initialEntries: [
+        { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
+      ],
+    });
+    renderWrapped(<SavingsFundChildOnboarding />, history);
+    userEvent.type(
+      await screen.findByLabelText(/Address \(street, house, apartment\)/i),
+      'Salapärane 1',
+    );
+
+    history.push('/savings-fund/onboarding/child', { childPersonalCode: OTHER_CHILD_CODE });
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Address \(street, house, apartment\)/i)).not.toHaveValue(
+        'Salapärane 1',
+      ),
+    );
+  });
+
+  it('keeps the parent contact prefill after switching to a different child', async () => {
+    const OTHER_CHILD_CODE = '61001010000';
+    const created = createChildBackend(server);
+    const history = createMemoryHistory({
+      initialEntries: [
+        { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
+      ],
+    });
+    renderWrapped(<SavingsFundChildOnboarding />, history);
+    expect(
+      await screen.findByRole('heading', { name: 'The child’s permanent residence' }),
+    ).toBeInTheDocument();
+
+    history.push('/savings-fund/onboarding/child', { childPersonalCode: OTHER_CHILD_CODE });
+
+    await waitFor(() =>
+      expect(created.createdWith).toEqual({ childPersonalCode: OTHER_CHILD_CODE }),
+    );
+    expect(
+      await screen.findByRole('heading', { name: 'The child’s permanent residence' }),
+    ).toBeInTheDocument();
+    userEvent.click(continueButton());
+
+    expect(await screen.findByText('3/8')).toBeInTheDocument(); // contact step
+    expect(screen.getByLabelText(/email/i)).toHaveValue(mockUser.email);
+  });
+
+  it('falls back to the child selector when the code itself is rejected', async () => {
+    server.use(
+      rest.post('http://localhost/v1/me/children', (req, res, ctx) =>
+        res(ctx.status(400), ctx.json({ errors: [{ code: 'invalid' }] })),
+      ),
+    );
+    const history = createMemoryHistory({
+      initialEntries: [
+        { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
+      ],
+    });
+    renderWrapped(<SavingsFundChildOnboarding />, history);
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByLabelText(/personal ID code/i)).toBeInTheDocument();
+  });
+
   it('falls back to the child selector when the switcher-picked child cannot be verified', async () => {
     createChildBackend(server, { status: 'UNDER_REVIEW' });
     const history = createMemoryHistory({

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -204,12 +204,18 @@ describe('SavingsFundChildOnboarding', () => {
 
   it('ignores a slow verification for a superseded child selection', async () => {
     const OTHER_CHILD_CODE = '61001010000';
+    let releaseStaleResponse!: () => void;
+    const staleResponseGate = new Promise<void>((resolve) => {
+      releaseStaleResponse = resolve;
+    });
+    let staleResponseServed = false;
     server.use(
       rest.post('http://localhost/v1/me/children', async (req, res, ctx) => {
         const { childPersonalCode } = req.body as { childPersonalCode: string };
         if (childPersonalCode === CHILD_CODE) {
+          await staleResponseGate;
+          staleResponseServed = true;
           return res(
-            ctx.delay(200),
             ctx.json({
               status: 'VERIFIED',
               firstName: 'Mammu',
@@ -247,9 +253,10 @@ describe('SavingsFundChildOnboarding', () => {
     const streetInput = await screen.findByLabelText(/Address \(street, house, apartment\)/i);
     expect(streetInput).toHaveValue('Fresh 2');
 
-    // Let the superseded first response arrive; it must not touch the form.
+    releaseStaleResponse();
+    await waitFor(() => expect(staleResponseServed).toBe(true));
     await new Promise((resolve) => {
-      setTimeout(resolve, 300);
+      setTimeout(resolve, 0);
     });
     expect(streetInput).toHaveValue('Fresh 2');
   });

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -84,10 +84,9 @@ describe('SavingsFundChildOnboarding', () => {
     expect(screen.getByLabelText(/personal ID code/i)).toBeInTheDocument();
   });
 
-  it('pre-selects the child passed via router state (co-parent from the account switcher)', async () => {
-    // The realistic co-parent case: the other guardian already opened the account,
-    // so the child arrives flagged hasBeenOnboarded and only the pending-onboarding
-    // entry keeps the option selectable.
+  it('skips the child selector when arriving from the account switcher and opens on the first question', async () => {
+    // The switcher click already was the selection: the picked child is verified
+    // in the background and the flow opens on the residency step.
     eligibleChildrenBackend(server, [
       {
         personalCode: CHILD_CODE,
@@ -99,6 +98,7 @@ describe('SavingsFundChildOnboarding', () => {
     pendingOnboardingsBackend(server, [
       { type: 'PERSON', code: CHILD_CODE, name: 'Mammu Maasikas' },
     ]);
+    const created = createChildBackend(server);
     const history = createMemoryHistory({
       initialEntries: [
         { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
@@ -106,12 +106,47 @@ describe('SavingsFundChildOnboarding', () => {
     });
     renderWrapped(<SavingsFundChildOnboarding />, history);
 
-    expect(await screen.findByRole('combobox', { name: /personal ID code/i })).toHaveValue(
-      CHILD_CODE,
+    expect(
+      await screen.findByRole('heading', { name: 'The child’s permanent residence' }),
+    ).toBeInTheDocument();
+    expect(created.createdWith).toEqual({ childPersonalCode: CHILD_CODE });
+    expect(screen.queryByLabelText(/personal ID code/i)).not.toBeInTheDocument();
+  });
+
+  it('restarts the flow for a different child picked from the account switcher', async () => {
+    const OTHER_CHILD_CODE = '61001010000';
+    const created = createChildBackend(server);
+    const history = createMemoryHistory({
+      initialEntries: [
+        { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
+      ],
+    });
+    renderWrapped(<SavingsFundChildOnboarding />, history);
+    expect(
+      await screen.findByRole('heading', { name: 'The child’s permanent residence' }),
+    ).toBeInTheDocument();
+
+    history.push('/savings-fund/onboarding/child', { childPersonalCode: OTHER_CHILD_CODE });
+
+    await waitFor(() =>
+      expect(created.createdWith).toEqual({ childPersonalCode: OTHER_CHILD_CODE }),
     );
     expect(
-      await screen.findByRole('option', { name: `Mammu Maasikas (${CHILD_CODE})` }),
-    ).toBeEnabled();
+      await screen.findByRole('heading', { name: 'The child’s permanent residence' }),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the child selector when the switcher-picked child cannot be verified', async () => {
+    createChildBackend(server, { status: 'UNDER_REVIEW' });
+    const history = createMemoryHistory({
+      initialEntries: [
+        { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
+      ],
+    });
+    renderWrapped(<SavingsFundChildOnboarding />, history);
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByLabelText(/personal ID code/i)).toBeInTheDocument();
   });
 
   it('skips the confirm step when a child is picked from the dropdown', async () => {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -145,16 +145,17 @@ describe('SavingsFundChildOnboarding', () => {
       ],
     });
     renderWrapped(<SavingsFundChildOnboarding />, history);
-    userEvent.type(
-      await screen.findByLabelText(/Address \(street, house, apartment\)/i),
-      'Salapärane 1',
-    );
+    const streetInput = await screen.findByLabelText(/Address \(street, house, apartment\)/i);
+    // The register response prefills the street; typing appends to it, proving
+    // below that the reset (back to the fresh prefill) actually happened.
+    userEvent.type(streetInput, 'Salapärane 1');
+    expect(streetInput).toHaveValue('Pärnu mnt 10Salapärane 1');
 
     history.push('/savings-fund/onboarding/child', { childPersonalCode: OTHER_CHILD_CODE });
 
     await waitFor(() =>
-      expect(screen.getByLabelText(/Address \(street, house, apartment\)/i)).not.toHaveValue(
-        'Salapärane 1',
+      expect(screen.getByLabelText(/Address \(street, house, apartment\)/i)).toHaveValue(
+        'Pärnu mnt 10',
       ),
     );
   });
@@ -201,6 +202,60 @@ describe('SavingsFundChildOnboarding', () => {
 
     expect(await screen.findByRole('alert')).toBeInTheDocument();
     expect(screen.getByLabelText(/personal ID code/i)).toBeInTheDocument();
+  });
+
+  it('ignores a slow verification for a superseded child selection', async () => {
+    const OTHER_CHILD_CODE = '61001010000';
+    server.use(
+      rest.post('http://localhost/v1/me/children', async (req, res, ctx) => {
+        const { childPersonalCode } = req.body as { childPersonalCode: string };
+        if (childPersonalCode === CHILD_CODE) {
+          return res(
+            ctx.delay(200),
+            ctx.json({
+              status: 'VERIFIED',
+              firstName: 'Mammu',
+              lastName: 'Maasikas',
+              dateOfBirth: '2015-09-07',
+              address: {
+                countryCode: 'EE',
+                street: 'Stale 1',
+                city: 'Tallinn',
+                postalCode: '10141',
+              },
+            }),
+          );
+        }
+        return res(
+          ctx.json({
+            status: 'VERIFIED',
+            firstName: 'Teine',
+            lastName: 'Laps',
+            dateOfBirth: '2016-01-01',
+            address: { countryCode: 'EE', street: 'Fresh 2', city: 'Tartu', postalCode: '50050' },
+          }),
+        );
+      }),
+    );
+    const history = createMemoryHistory({
+      initialEntries: [
+        { pathname: '/savings-fund/onboarding/child', state: { childPersonalCode: CHILD_CODE } },
+      ],
+    });
+    renderWrapped(<SavingsFundChildOnboarding />, history);
+
+    // Supersede the slow verification for the first child immediately.
+    history.push('/savings-fund/onboarding/child', { childPersonalCode: OTHER_CHILD_CODE });
+
+    const streetInput = await screen.findByLabelText(/Address \(street, house, apartment\)/i);
+    expect(streetInput).toHaveValue('Fresh 2');
+
+    // Let the superseded response for the first child arrive — it must not
+    // overwrite the current child's form.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    });
+    expect(streetInput).toHaveValue('Fresh 2');
   });
 
   it('falls back to the child selector when the switcher-picked child cannot be verified', async () => {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -85,8 +85,6 @@ describe('SavingsFundChildOnboarding', () => {
   });
 
   it('skips the child selector when arriving from the account switcher and opens on the first question', async () => {
-    // The switcher click already was the selection: the picked child is verified
-    // in the background and the flow opens on the residency step.
     eligibleChildrenBackend(server, [
       {
         personalCode: CHILD_CODE,
@@ -244,14 +242,12 @@ describe('SavingsFundChildOnboarding', () => {
     });
     renderWrapped(<SavingsFundChildOnboarding />, history);
 
-    // Supersede the slow verification for the first child immediately.
     history.push('/savings-fund/onboarding/child', { childPersonalCode: OTHER_CHILD_CODE });
 
     const streetInput = await screen.findByLabelText(/Address \(street, house, apartment\)/i);
     expect(streetInput).toHaveValue('Fresh 2');
 
-    // Let the superseded response for the first child arrive — it must not
-    // overwrite the current child's form.
+    // Let the superseded first response arrive; it must not touch the form.
     await new Promise((resolve) => {
       setTimeout(resolve, 300);
     });

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -27,11 +27,14 @@ import { getSavingsFundOnboardingStatus } from '../../../common/api';
 import { transformChildFormDataToSurveyCommand } from '../utils';
 import { TKF_DOCUMENTS } from './tkfDocuments';
 
-// The step components only touch the identity fields; narrowing the control is
-// structurally safe for any form that includes them (mirrors identitySteps.tsx).
 const asIdentityControl = (
   control: Control<ChildOnboardingFormData>,
 ): Control<IdentityFormFields> => control as unknown as Control<IdentityFormFields>;
+
+const isChildCodeRejection = (error: unknown): boolean => {
+  const status = (error as { status?: number } | undefined)?.status;
+  return status !== undefined && status >= 400 && status < 500;
+};
 
 const emptyChildOnboardingForm = (childPersonalCode: string): ChildOnboardingFormData => ({
   childPersonalCode,
@@ -56,22 +59,12 @@ export const SavingsFundChildOnboarding = () => {
   const arrivedFromSwitcher = Boolean(switcherPickedChildCode);
   const [activeSection, setActiveSection] = useState(0);
   const [submitError, setSubmitError] = useState(false);
-  // The entered code can't open an account for a child — either it's not a valid
-  // isikukood, or the parent has no asset-management custody over that child. One
-  // inline message, kept uniform so it can't reveal whether the child exists.
+  // One uniform rejection message, so responses can't reveal whether a child exists.
   const [childCodeRejected, setChildCodeRejected] = useState(false);
-  // Terminal state: after switching to the child, we could not switch back to the
-  // parent. Rather than leave the parent silently stranded in the child role, show
-  // an explicit "please reload" and report it.
-  const [rollbackFailed, setRollbackFailed] = useState(false);
-  // Covers the whole finalize critical section (switch → submit → status → nav),
-  // so both Continue and Back stay disabled until it resolves.
+  const [strandedInChildRole, setStrandedInChildRole] = useState(false);
   const [isFinalizing, setIsFinalizing] = useState(false);
-  // null until the identity step verifies; then true when the code wasn't one of
-  // the offered children (typed manually, or the dropdown never loaded), false when
-  // picked from the named dropdown — the pick is itself the confirmation. Before
-  // verifying, fall back to "is a dropdown even available" so the total step count
-  // matches the path the parent is most likely on and doesn't lurch after step 1.
+  // null until verified; until then the step count falls back to "is a dropdown
+  // even available" so the total doesn't lurch after step 1.
   const [manualConfirm, setManualConfirm] = useState<boolean | null>(() =>
     arrivedFromSwitcher ? false : null,
   );
@@ -91,9 +84,7 @@ export const SavingsFundChildOnboarding = () => {
   const child = watch('child');
   const termsAccepted = watch('termsAccepted');
 
-  // Default the contact to the parent's own, as the child's representative until
-  // 18. Applied once and only into still-empty fields, so a later /v1/me refetch
-  // can't clobber a child's own email the parent typed on the contact step.
+  // Once only, and only into empty fields: a /v1/me refetch must not clobber typed contacts.
   const contactPrefilledRef = useRef(false);
   const prefillParentContactIfEmpty = useCallback(() => {
     if (!me) {
@@ -255,8 +246,7 @@ export const SavingsFundChildOnboarding = () => {
         if (superseded()) {
           return;
         }
-        // Branch on the body status, never the HTTP code; a VERIFIED response with
-        // no name is malformed and treated as "under review", not advanced.
+        // A VERIFIED body without a name is malformed — treat it as under review.
         if (response.status === 'VERIFIED' && response.firstName) {
           setValue('child', {
             firstName: response.firstName,
@@ -266,28 +256,19 @@ export const SavingsFundChildOnboarding = () => {
           if (response.address) {
             setValue('address', response.address);
           }
-          // Confirm the child only when the code wasn't one of the named options the
-          // parent could pick — a manually typed code, or the dropdown never loaded.
-          // A child picked by name in the account switcher counts as picked. Either
-          // way index 1 is the next step (confirm if shown, else residency), so
-          // setActiveSection(1) is correct for both.
-          const pickedFromList =
-            pickedByName || eligibleChildren.some((c) => c.personalCode === childPersonalCode);
-          setManualConfirm(!pickedFromList);
+          const pickedFromKnownChildren = eligibleChildren.some(
+            (c) => c.personalCode === childPersonalCode,
+          );
+          setManualConfirm(!pickedByName && !pickedFromKnownChildren);
           setActiveSection(1);
         } else {
-          // UNDER_REVIEW — custody couldn't be confirmed (not the parent's child, no
-          // asset-management right, or no such child). Uniform message, no reason.
           setChildCodeRejected(true);
         }
       } catch (error) {
         if (superseded()) {
           return;
         }
-        // A 4xx means the code itself was rejected (an invalid isikukood) — same
-        // "check the code" message. Anything else is a genuine system/network error.
-        const status = (error as { status?: number } | undefined)?.status;
-        if (status !== undefined && status >= 400 && status < 500) {
+        if (isChildCodeRejection(error)) {
           setChildCodeRejected(true);
         } else {
           setSubmitError(true);
@@ -319,16 +300,13 @@ export const SavingsFundChildOnboarding = () => {
     });
   }, [isFinalizing, switcherPickedChildCode, prefillParentContactIfEmpty, reset, verifyChild]);
 
-  // The one and only role switch. Everything before this ran as the parent; the
-  // child KYC must be submitted while acting as the child (role-aware backend).
+  // The child KYC must be submitted while acting as the child (role-aware backend).
   const finalize = async (): Promise<void> => {
     // Snapshot before the awaits: a switcher pick landing mid-finalize resets the form.
     const confirmedForm = getValues();
     const childCode = confirmedForm.childPersonalCode;
     const parentCode = me?.personalCode;
-    // Never switch to the child before we know the parent code to switch back to,
-    // otherwise a non-completed submit could strand the parent (the terms-step
-    // Continue is also gated on this, so this is a belt-and-suspenders guard).
+    // Without a parent code to switch back to, a failed submit would strand the parent.
     if (!parentCode) {
       setSubmitError(true);
       return;
@@ -365,7 +343,7 @@ export const SavingsFundChildOnboarding = () => {
       await switchRole({ type: 'PERSON', code: parentCode });
     } catch {
       captureException(new Error('Child onboarding: failed to switch back to the parent role'));
-      setRollbackFailed(true);
+      setStrandedInChildRole(true);
       return;
     }
 
@@ -407,7 +385,7 @@ export const SavingsFundChildOnboarding = () => {
     }
   };
 
-  if (rollbackFailed) {
+  if (strandedInChildRole) {
     return (
       <div className="col-12 col-md-10 col-lg-7 mx-auto">
         <div className="d-flex flex-column gap-4 align-items-start">

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Control, useForm } from 'react-hook-form';
 import { useHistory, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
@@ -74,7 +74,11 @@ export const SavingsFundChildOnboarding = () => {
   // picked from the named dropdown — the pick is itself the confirmation. Before
   // verifying, fall back to "is a dropdown even available" so the total step count
   // matches the path the parent is most likely on and doesn't lurch after step 1.
-  const [manualConfirm, setManualConfirm] = useState<boolean | null>(null);
+  // A switcher-picked child is a named pick from the start, so the confirm step
+  // never enters the count and the step total cannot lurch while queries load.
+  const [manualConfirm, setManualConfirm] = useState<boolean | null>(() =>
+    joinChildPersonalCode ? false : null,
+  );
   // True while a switcher-picked child is being verified in the background, so
   // the selector never flashes; verification failure falls back to the selector.
   const [autoVerifying, setAutoVerifying] = useState(() => Boolean(joinChildPersonalCode));
@@ -238,55 +242,77 @@ export const SavingsFundChildOnboarding = () => {
   const totalSections = steps.length;
   const isTermsStep = activeSection === totalSections - 1;
 
-  const verifyChild = async ({ pickedByName = false } = {}): Promise<void> => {
-    try {
-      setSubmitError(false);
-      setChildCodeRejected(false);
-      const childPersonalCode = getValues('childPersonalCode');
-      const response = await createChild({ childPersonalCode });
-      // Branch on the body status, never the HTTP code; a VERIFIED response with
-      // no name is malformed and treated as "under review", not advanced.
-      if (response.status === 'VERIFIED' && response.firstName) {
-        setValue('child', {
-          firstName: response.firstName,
-          lastName: response.lastName ?? '',
-          dateOfBirth: response.dateOfBirth ?? '',
-        });
-        if (response.address) {
-          setValue('address', response.address);
+  // Each verification carries a generation number; a response whose generation
+  // is no longer current was superseded by a newer child selection and must not
+  // touch the form — a slow response for child A landing after child B's would
+  // otherwise put A's identity and address under B's code.
+  const verifyGenerationRef = useRef(0);
+  const verifyChild = useCallback(
+    async ({ pickedByName = false } = {}): Promise<void> => {
+      verifyGenerationRef.current += 1;
+      const generation = verifyGenerationRef.current;
+      try {
+        setSubmitError(false);
+        setChildCodeRejected(false);
+        const childPersonalCode = getValues('childPersonalCode');
+        const response = await createChild({ childPersonalCode });
+        if (generation !== verifyGenerationRef.current) {
+          return;
         }
-        // Confirm the child only when the code wasn't one of the named options the
-        // parent could pick — a manually typed code, or the dropdown never loaded.
-        // A child picked by name in the account switcher counts as picked. Either
-        // way index 1 is the next step (confirm if shown, else residency), so
-        // setActiveSection(1) is correct for both.
-        const pickedFromList =
-          pickedByName || eligibleChildren.some((c) => c.personalCode === childPersonalCode);
-        setManualConfirm(!pickedFromList);
-        setActiveSection(1);
-      } else {
-        // UNDER_REVIEW — custody couldn't be confirmed (not the parent's child, no
-        // asset-management right, or no such child). Uniform message, no reason.
-        setChildCodeRejected(true);
+        // Branch on the body status, never the HTTP code; a VERIFIED response with
+        // no name is malformed and treated as "under review", not advanced.
+        if (response.status === 'VERIFIED' && response.firstName) {
+          setValue('child', {
+            firstName: response.firstName,
+            lastName: response.lastName ?? '',
+            dateOfBirth: response.dateOfBirth ?? '',
+          });
+          if (response.address) {
+            setValue('address', response.address);
+          }
+          // Confirm the child only when the code wasn't one of the named options the
+          // parent could pick — a manually typed code, or the dropdown never loaded.
+          // A child picked by name in the account switcher counts as picked. Either
+          // way index 1 is the next step (confirm if shown, else residency), so
+          // setActiveSection(1) is correct for both.
+          const pickedFromList =
+            pickedByName || eligibleChildren.some((c) => c.personalCode === childPersonalCode);
+          setManualConfirm(!pickedFromList);
+          setActiveSection(1);
+        } else {
+          // UNDER_REVIEW — custody couldn't be confirmed (not the parent's child, no
+          // asset-management right, or no such child). Uniform message, no reason.
+          setChildCodeRejected(true);
+        }
+      } catch (error) {
+        if (generation !== verifyGenerationRef.current) {
+          return;
+        }
+        // A 4xx means the code itself was rejected (an invalid isikukood) — same
+        // "check the code" message. Anything else is a genuine system/network error.
+        const status = (error as { status?: number } | undefined)?.status;
+        if (status !== undefined && status >= 400 && status < 500) {
+          setChildCodeRejected(true);
+        } else {
+          setSubmitError(true);
+        }
       }
-    } catch (error) {
-      // A 4xx means the code itself was rejected (an invalid isikukood) — same
-      // "check the code" message. Anything else is a genuine system/network error.
-      const status = (error as { status?: number } | undefined)?.status;
-      if (status !== undefined && status >= 400 && status < 500) {
-        setChildCodeRejected(true);
-      } else {
-        setSubmitError(true);
-      }
-    }
-  };
+    },
+    [createChild, eligibleChildren, getValues, setValue],
+  );
 
   // Verify the switcher-picked child automatically — and when a different child
   // is picked from the switcher while the flow is open, restart it for that
   // child with a clean form so nothing entered for the previous child leaks.
   const autoVerifiedCodeRef = useRef('');
   useEffect(() => {
-    if (!joinChildPersonalCode || autoVerifiedCodeRef.current === joinChildPersonalCode) {
+    // Never restart the flow mid-finalize: the role switch to the child may be
+    // in flight, and resetting the form under it would corrupt the submission.
+    if (
+      isFinalizing ||
+      !joinChildPersonalCode ||
+      autoVerifiedCodeRef.current === joinChildPersonalCode
+    ) {
       return;
     }
     autoVerifiedCodeRef.current = joinChildPersonalCode;
@@ -304,13 +330,24 @@ export const SavingsFundChildOnboarding = () => {
     setManualConfirm(false);
     setActiveSection(0);
     setAutoVerifying(true);
-    verifyChild({ pickedByName: true }).finally(() => setAutoVerifying(false));
-  }, [joinChildPersonalCode, me, reset, setValue, verifyChild]);
+    verifyChild({ pickedByName: true }).finally(() => {
+      // Only the verification for the still-current child may clear the loader; a
+      // superseded one finishing late must not reveal the next child's step while
+      // its own verification is still in flight.
+      if (autoVerifiedCodeRef.current === joinChildPersonalCode) {
+        setAutoVerifying(false);
+      }
+    });
+  }, [isFinalizing, joinChildPersonalCode, me, reset, setValue, verifyChild]);
 
   // The one and only role switch. Everything before this ran as the parent; the
   // child KYC must be submitted while acting as the child (role-aware backend).
   const finalize = async (): Promise<void> => {
-    const childCode = getValues('childPersonalCode');
+    // Snapshot the whole form up front: the submit below happens after awaits,
+    // and a switcher pick landing in that window resets the form — the survey
+    // must be built from what the parent actually confirmed, not a later read.
+    const formData = getValues();
+    const childCode = formData.childPersonalCode;
     const parentCode = me?.personalCode;
     // Never switch to the child before we know the parent code to switch back to,
     // otherwise a non-completed submit could strand the parent (the terms-step
@@ -333,7 +370,7 @@ export const SavingsFundChildOnboarding = () => {
 
     let outcome: 'completed' | 'pending' | 'error' = 'error';
     try {
-      await submitSurvey(transformChildFormDataToSurveyCommand(getValues()));
+      await submitSurvey(transformChildFormDataToSurveyCommand(formData));
       // One-shot read on the child token — the acting-party status is the child's.
       const status = await getSavingsFundOnboardingStatus();
       outcome = status.status === 'COMPLETED' ? 'completed' : 'pending';

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -4,6 +4,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { captureException } from '@sentry/browser';
 import { ChildOnboardingFormData, IdentityFormFields } from './types';
+import { Loader } from '../../../common';
 import { ChildIdentityStep } from './ChildIdentityStep';
 import { ChildConfirmStep } from './ChildConfirmStep';
 import { ResidencyStep } from './ResidencyStep';
@@ -32,13 +33,29 @@ const asIdentityControl = (
   control: Control<ChildOnboardingFormData>,
 ): Control<IdentityFormFields> => control as unknown as Control<IdentityFormFields>;
 
+const emptyChildOnboardingForm = (childPersonalCode: string): ChildOnboardingFormData => ({
+  childPersonalCode,
+  child: null,
+  citizenship: [],
+  address: { countryCode: 'EE', street: '', city: '', postalCode: '' },
+  email: '',
+  phoneNumber: '',
+  pepSelfDeclaration: null,
+  investmentGoals: [],
+  plannedContribution: null,
+  investableAssets: null,
+  fundingSources: [],
+  termsAccepted: false,
+});
+
 export const SavingsFundChildOnboarding = () => {
   const history = useHistory();
   // A co-guardian arriving from the account switcher carries the child's personal
-  // code in router state (never the URL). Pre-select it so the identity step opens
-  // on that child; falls back to empty for the parent opening a new account.
+  // code in router state (never the URL). The click on the child's name already
+  // was the selection, so the selector step is skipped: the code is verified
+  // automatically and the flow opens on the first question step.
   const { state: locationState } = useLocation<{ childPersonalCode?: string } | undefined>();
-  const preselectedChildPersonalCode = locationState?.childPersonalCode ?? '';
+  const joinChildPersonalCode = locationState?.childPersonalCode ?? '';
   const [activeSection, setActiveSection] = useState(0);
   const [submitError, setSubmitError] = useState(false);
   // The entered code can't open an account for a child — either it's not a valid
@@ -58,6 +75,9 @@ export const SavingsFundChildOnboarding = () => {
   // verifying, fall back to "is a dropdown even available" so the total step count
   // matches the path the parent is most likely on and doesn't lurch after step 1.
   const [manualConfirm, setManualConfirm] = useState<boolean | null>(null);
+  // True while a switcher-picked child is being verified in the background, so
+  // the selector never flashes; verification failure falls back to the selector.
+  const [autoVerifying, setAutoVerifying] = useState(() => Boolean(joinChildPersonalCode));
 
   const { data: me } = useMe();
   const { data: eligibleChildren = [] } = useEligibleChildren();
@@ -65,22 +85,9 @@ export const SavingsFundChildOnboarding = () => {
   const { mutateAsync: submitSurvey } = useSubmitSavingsFundOnboardingSurvey();
   const { mutateAsync: switchRole } = useSwitchRole();
 
-  const { control, trigger, watch, setValue, getValues } = useForm<ChildOnboardingFormData>({
+  const { control, trigger, watch, setValue, getValues, reset } = useForm<ChildOnboardingFormData>({
     mode: 'onSubmit',
-    defaultValues: {
-      childPersonalCode: preselectedChildPersonalCode,
-      child: null,
-      citizenship: [],
-      address: { countryCode: 'EE', street: '', city: '', postalCode: '' },
-      email: '',
-      phoneNumber: '',
-      pepSelfDeclaration: null,
-      investmentGoals: [],
-      plannedContribution: null,
-      investableAssets: null,
-      fundingSources: [],
-      termsAccepted: false,
-    },
+    defaultValues: emptyChildOnboardingForm(joinChildPersonalCode),
   });
 
   const child = watch('child');
@@ -231,7 +238,7 @@ export const SavingsFundChildOnboarding = () => {
   const totalSections = steps.length;
   const isTermsStep = activeSection === totalSections - 1;
 
-  const verifyChild = async (): Promise<void> => {
+  const verifyChild = async ({ pickedByName = false } = {}): Promise<void> => {
     try {
       setSubmitError(false);
       setChildCodeRejected(false);
@@ -250,9 +257,11 @@ export const SavingsFundChildOnboarding = () => {
         }
         // Confirm the child only when the code wasn't one of the named options the
         // parent could pick — a manually typed code, or the dropdown never loaded.
-        // Either way index 1 is the next step (confirm if shown, else residency),
-        // so setActiveSection(1) is correct for both.
-        const pickedFromList = eligibleChildren.some((c) => c.personalCode === childPersonalCode);
+        // A child picked by name in the account switcher counts as picked. Either
+        // way index 1 is the next step (confirm if shown, else residency), so
+        // setActiveSection(1) is correct for both.
+        const pickedFromList =
+          pickedByName || eligibleChildren.some((c) => c.personalCode === childPersonalCode);
         setManualConfirm(!pickedFromList);
         setActiveSection(1);
       } else {
@@ -271,6 +280,32 @@ export const SavingsFundChildOnboarding = () => {
       }
     }
   };
+
+  // Verify the switcher-picked child automatically — and when a different child
+  // is picked from the switcher while the flow is open, restart it for that
+  // child with a clean form so nothing entered for the previous child leaks.
+  const autoVerifiedCodeRef = useRef('');
+  useEffect(() => {
+    if (!joinChildPersonalCode || autoVerifiedCodeRef.current === joinChildPersonalCode) {
+      return;
+    }
+    autoVerifiedCodeRef.current = joinChildPersonalCode;
+    reset(emptyChildOnboardingForm(joinChildPersonalCode));
+    contactPrefilledRef.current = false;
+    if (me) {
+      contactPrefilledRef.current = true;
+      if (me.email) {
+        setValue('email', me.email);
+      }
+      if (me.phoneNumber) {
+        setValue('phoneNumber', me.phoneNumber);
+      }
+    }
+    setManualConfirm(false);
+    setActiveSection(0);
+    setAutoVerifying(true);
+    verifyChild({ pickedByName: true }).finally(() => setAutoVerifying(false));
+  }, [joinChildPersonalCode, me, reset, setValue, verifyChild]);
 
   // The one and only role switch. Everything before this ran as the parent; the
   // child KYC must be submitted while acting as the child (role-aware backend).
@@ -389,11 +424,11 @@ export const SavingsFundChildOnboarding = () => {
         totalSteps={totalSections}
         onBack={showPreviousSection}
         onNext={showNextSection}
-        submitting={creatingChild || isFinalizing}
+        submitting={creatingChild || isFinalizing || autoVerifying}
         backDisabled={isFinalizing}
         nextDisabled={isTermsStep && (!termsAccepted || !me?.personalCode)}
       >
-        {steps[activeSection].component}
+        {autoVerifying ? <Loader className="align-middle" /> : steps[activeSection].component}
 
         {childCodeRejected ? (
           <div className="alert alert-danger mt-4" role="alert">

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -232,12 +232,21 @@ export const SavingsFundChildOnboarding = () => {
   const totalSections = steps.length;
   const isTermsStep = activeSection === totalSections - 1;
 
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
+
   const latestVerificationRef = useRef(0);
   const verifyChild = useCallback(
     async ({ pickedByName = false } = {}): Promise<void> => {
       latestVerificationRef.current += 1;
       const verification = latestVerificationRef.current;
-      const superseded = () => verification !== latestVerificationRef.current;
+      const superseded = () =>
+        !mountedRef.current || verification !== latestVerificationRef.current;
       try {
         setSubmitError(false);
         setChildCodeRejected(false);
@@ -294,7 +303,7 @@ export const SavingsFundChildOnboarding = () => {
     setVerifyingSwitcherPick(true);
     verifyChild({ pickedByName: true }).finally(() => {
       const stillCurrentPick = verifiedSwitcherPickRef.current === switcherPickedChildCode;
-      if (stillCurrentPick) {
+      if (mountedRef.current && stillCurrentPick) {
         setVerifyingSwitcherPick(false);
       }
     });
@@ -417,7 +426,7 @@ export const SavingsFundChildOnboarding = () => {
         onBack={showPreviousSection}
         onNext={showNextSection}
         submitting={creatingChild || isFinalizing || verifyingSwitcherPick}
-        backDisabled={isFinalizing}
+        backDisabled={isFinalizing || verifyingSwitcherPick}
         nextDisabled={isTermsStep && (!termsAccepted || !me?.personalCode)}
       >
         {verifyingSwitcherPick ? (

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -50,12 +50,10 @@ const emptyChildOnboardingForm = (childPersonalCode: string): ChildOnboardingFor
 
 export const SavingsFundChildOnboarding = () => {
   const history = useHistory();
-  // A co-guardian arriving from the account switcher carries the child's personal
-  // code in router state (never the URL). The click on the child's name already
-  // was the selection, so the selector step is skipped: the code is verified
-  // automatically and the flow opens on the first question step.
+  // Router state, never the URL: the minor's code must stay out of history and logs.
   const { state: locationState } = useLocation<{ childPersonalCode?: string } | undefined>();
-  const joinChildPersonalCode = locationState?.childPersonalCode ?? '';
+  const switcherPickedChildCode = locationState?.childPersonalCode ?? '';
+  const arrivedFromSwitcher = Boolean(switcherPickedChildCode);
   const [activeSection, setActiveSection] = useState(0);
   const [submitError, setSubmitError] = useState(false);
   // The entered code can't open an account for a child — either it's not a valid
@@ -74,14 +72,10 @@ export const SavingsFundChildOnboarding = () => {
   // picked from the named dropdown — the pick is itself the confirmation. Before
   // verifying, fall back to "is a dropdown even available" so the total step count
   // matches the path the parent is most likely on and doesn't lurch after step 1.
-  // A switcher-picked child is a named pick from the start, so the confirm step
-  // never enters the count and the step total cannot lurch while queries load.
   const [manualConfirm, setManualConfirm] = useState<boolean | null>(() =>
-    joinChildPersonalCode ? false : null,
+    arrivedFromSwitcher ? false : null,
   );
-  // True while a switcher-picked child is being verified in the background, so
-  // the selector never flashes; verification failure falls back to the selector.
-  const [autoVerifying, setAutoVerifying] = useState(() => Boolean(joinChildPersonalCode));
+  const [verifyingSwitcherPick, setVerifyingSwitcherPick] = useState(arrivedFromSwitcher);
 
   const { data: me } = useMe();
   const { data: eligibleChildren = [] } = useEligibleChildren();
@@ -91,7 +85,7 @@ export const SavingsFundChildOnboarding = () => {
 
   const { control, trigger, watch, setValue, getValues, reset } = useForm<ChildOnboardingFormData>({
     mode: 'onSubmit',
-    defaultValues: emptyChildOnboardingForm(joinChildPersonalCode),
+    defaultValues: emptyChildOnboardingForm(switcherPickedChildCode),
   });
 
   const child = watch('child');
@@ -101,8 +95,8 @@ export const SavingsFundChildOnboarding = () => {
   // 18. Applied once and only into still-empty fields, so a later /v1/me refetch
   // can't clobber a child's own email the parent typed on the contact step.
   const contactPrefilledRef = useRef(false);
-  useEffect(() => {
-    if (!me || contactPrefilledRef.current) {
+  const prefillParentContactIfEmpty = useCallback(() => {
+    if (!me) {
       return;
     }
     contactPrefilledRef.current = true;
@@ -113,6 +107,11 @@ export const SavingsFundChildOnboarding = () => {
       setValue('phoneNumber', me.phoneNumber);
     }
   }, [me, getValues, setValue]);
+  useEffect(() => {
+    if (!contactPrefilledRef.current) {
+      prefillParentContactIfEmpty();
+    }
+  }, [prefillParentContactIfEmpty]);
 
   const includeConfirmStep = manualConfirm ?? eligibleChildren.length === 0;
   const confirmStep: OnboardingStep<ChildOnboardingFormData>[] = includeConfirmStep
@@ -242,21 +241,18 @@ export const SavingsFundChildOnboarding = () => {
   const totalSections = steps.length;
   const isTermsStep = activeSection === totalSections - 1;
 
-  // Each verification carries a generation number; a response whose generation
-  // is no longer current was superseded by a newer child selection and must not
-  // touch the form — a slow response for child A landing after child B's would
-  // otherwise put A's identity and address under B's code.
-  const verifyGenerationRef = useRef(0);
+  const latestVerificationRef = useRef(0);
   const verifyChild = useCallback(
     async ({ pickedByName = false } = {}): Promise<void> => {
-      verifyGenerationRef.current += 1;
-      const generation = verifyGenerationRef.current;
+      latestVerificationRef.current += 1;
+      const verification = latestVerificationRef.current;
+      const superseded = () => verification !== latestVerificationRef.current;
       try {
         setSubmitError(false);
         setChildCodeRejected(false);
         const childPersonalCode = getValues('childPersonalCode');
         const response = await createChild({ childPersonalCode });
-        if (generation !== verifyGenerationRef.current) {
+        if (superseded()) {
           return;
         }
         // Branch on the body status, never the HTTP code; a VERIFIED response with
@@ -285,7 +281,7 @@ export const SavingsFundChildOnboarding = () => {
           setChildCodeRejected(true);
         }
       } catch (error) {
-        if (generation !== verifyGenerationRef.current) {
+        if (superseded()) {
           return;
         }
         // A 4xx means the code itself was rejected (an invalid isikukood) — same
@@ -301,53 +297,34 @@ export const SavingsFundChildOnboarding = () => {
     [createChild, eligibleChildren, getValues, setValue],
   );
 
-  // Verify the switcher-picked child automatically — and when a different child
-  // is picked from the switcher while the flow is open, restart it for that
-  // child with a clean form so nothing entered for the previous child leaks.
-  const autoVerifiedCodeRef = useRef('');
+  const verifiedSwitcherPickRef = useRef('');
   useEffect(() => {
-    // Never restart the flow mid-finalize: the role switch to the child may be
-    // in flight, and resetting the form under it would corrupt the submission.
-    if (
-      isFinalizing ||
-      !joinChildPersonalCode ||
-      autoVerifiedCodeRef.current === joinChildPersonalCode
-    ) {
+    const isNewSwitcherPick =
+      switcherPickedChildCode && verifiedSwitcherPickRef.current !== switcherPickedChildCode;
+    if (!isNewSwitcherPick || isFinalizing) {
       return;
     }
-    autoVerifiedCodeRef.current = joinChildPersonalCode;
-    reset(emptyChildOnboardingForm(joinChildPersonalCode));
+    verifiedSwitcherPickRef.current = switcherPickedChildCode;
+    reset(emptyChildOnboardingForm(switcherPickedChildCode));
     contactPrefilledRef.current = false;
-    if (me) {
-      contactPrefilledRef.current = true;
-      if (me.email) {
-        setValue('email', me.email);
-      }
-      if (me.phoneNumber) {
-        setValue('phoneNumber', me.phoneNumber);
-      }
-    }
+    prefillParentContactIfEmpty();
     setManualConfirm(false);
     setActiveSection(0);
-    setAutoVerifying(true);
+    setVerifyingSwitcherPick(true);
     verifyChild({ pickedByName: true }).finally(() => {
-      // Only the verification for the still-current child may clear the loader; a
-      // superseded one finishing late must not reveal the next child's step while
-      // its own verification is still in flight.
-      if (autoVerifiedCodeRef.current === joinChildPersonalCode) {
-        setAutoVerifying(false);
+      const stillCurrentPick = verifiedSwitcherPickRef.current === switcherPickedChildCode;
+      if (stillCurrentPick) {
+        setVerifyingSwitcherPick(false);
       }
     });
-  }, [isFinalizing, joinChildPersonalCode, me, reset, setValue, verifyChild]);
+  }, [isFinalizing, switcherPickedChildCode, prefillParentContactIfEmpty, reset, verifyChild]);
 
   // The one and only role switch. Everything before this ran as the parent; the
   // child KYC must be submitted while acting as the child (role-aware backend).
   const finalize = async (): Promise<void> => {
-    // Snapshot the whole form up front: the submit below happens after awaits,
-    // and a switcher pick landing in that window resets the form — the survey
-    // must be built from what the parent actually confirmed, not a later read.
-    const formData = getValues();
-    const childCode = formData.childPersonalCode;
+    // Snapshot before the awaits: a switcher pick landing mid-finalize resets the form.
+    const confirmedForm = getValues();
+    const childCode = confirmedForm.childPersonalCode;
     const parentCode = me?.personalCode;
     // Never switch to the child before we know the parent code to switch back to,
     // otherwise a non-completed submit could strand the parent (the terms-step
@@ -370,7 +347,7 @@ export const SavingsFundChildOnboarding = () => {
 
     let outcome: 'completed' | 'pending' | 'error' = 'error';
     try {
-      await submitSurvey(transformChildFormDataToSurveyCommand(formData));
+      await submitSurvey(transformChildFormDataToSurveyCommand(confirmedForm));
       // One-shot read on the child token — the acting-party status is the child's.
       const status = await getSavingsFundOnboardingStatus();
       outcome = status.status === 'COMPLETED' ? 'completed' : 'pending';
@@ -461,11 +438,15 @@ export const SavingsFundChildOnboarding = () => {
         totalSteps={totalSections}
         onBack={showPreviousSection}
         onNext={showNextSection}
-        submitting={creatingChild || isFinalizing || autoVerifying}
+        submitting={creatingChild || isFinalizing || verifyingSwitcherPick}
         backDisabled={isFinalizing}
         nextDisabled={isTermsStep && (!termsAccepted || !me?.personalCode)}
       >
-        {autoVerifying ? <Loader className="align-middle" /> : steps[activeSection].component}
+        {verifyingSwitcherPick ? (
+          <Loader className="align-middle" />
+        ) : (
+          steps[activeSection].component
+        )}
 
         {childCodeRejected ? (
           <div className="alert alert-danger mt-4" role="alert">


### PR DESCRIPTION
Follow-up to #1602 based on live testing feedback.

**What changed**
- Clicking a child's name in the account switcher already *is* the selection, so the flow now verifies that child in the background (loader instead of the selector step) and opens directly on the residency step.
- If verification fails (custody revoked, register hiccup), the flow falls back to the normal selector with the usual uniform error message.

**Bug fixed along the way**
Picking a *second* child from the switcher while the flow was already open kept showing the first child — the router-state code was only read into the form's mount-time defaults, and the component doesn't remount on a same-route navigation. Picking a different child now fully resets the form and re-verifies, so nothing entered for the previous child leaks into the next one.

**Tests**: three new cases (skip-and-open-on-residency, restart-for-second-child, fallback-on-verification-failure); full suite green (1615 tests).