### PR TITLE
Pre-fill savings-fund deposit amount with a default

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -35,6 +35,21 @@ describe(SavingsFundPayment, () => {
   const findPageHeading = () =>
     screen.findByRole('heading', { name: 'Deposit to Additional Savings Fund' });
 
+  const getAmountInput = () => screen.getByRole('textbox', { name: 'Amount' });
+
+  // The amount field is pre-filled with a default deposit amount, so replace it
+  // rather than appending. {selectall} selects the default and the typed value
+  // overwrites it in a single call (a bare clear()+type() races the controlled
+  // input's value sync and would append to the default instead).
+  const typeAmount = (value: string) => {
+    const amountInput = getAmountInput();
+    if (value === '') {
+      userEvent.clear(amountInput);
+      return;
+    }
+    userEvent.type(amountInput, `{selectall}${value}`);
+  };
+
   beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
   afterEach(() => server.resetHandlers());
   afterAll(() => server.close());
@@ -46,28 +61,33 @@ describe(SavingsFundPayment, () => {
     history.push('/savings-fund/payment');
   });
 
+  it('pre-fills the deposit amount with 250 for an adult', async () => {
+    expect(await findPageHeading()).toBeInTheDocument();
+    expect(getAmountInput()).toHaveValue('250');
+  });
+
   it('validates the deposit amount and bank selection', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
+    const amountInput = getAmountInput();
     const submitButton = screen.getByRole('button', { name: 'Continue' });
     const amountValidationMessage = 'The deposit amount must be at least one euro.';
     const bankSelectionValidationMessage = 'Select the bank you want to use for the deposit.';
 
     expect(amountInput).toBeInTheDocument();
 
-    // Trigger minimum amount validation
-    userEvent.type(amountInput, '0.5');
+    // Trigger minimum amount validation (replaces the pre-filled default)
+    typeAmount('0.5');
     userEvent.click(submitButton); // Trigger validation
     expect(await screen.findByText(amountValidationMessage)).toBeInTheDocument();
 
     // Trigger required field validation
-    userEvent.clear(amountInput);
+    typeAmount('');
     userEvent.click(submitButton); // Trigger validation
     expect(await screen.findByText(amountValidationMessage)).toBeInTheDocument();
 
     // Enter valid amount
-    userEvent.type(amountInput, '123.45');
+    typeAmount('123.45');
     userEvent.click(submitButton); // Trigger validation
     expect(amountInput).toHaveValue('123.45');
     await waitFor(() =>
@@ -110,8 +130,7 @@ describe(SavingsFundPayment, () => {
   it('does not show investment account reminder when amount is 15000 or more', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
-    userEvent.type(amountInput, '15000');
+    typeAmount('15000');
 
     expect(await screen.findByText('Did you make the payment?')).toBeInTheDocument();
     expect(
@@ -122,9 +141,8 @@ describe(SavingsFundPayment, () => {
   it('lets user select a bank and start the payment', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
     const submitButton = screen.getByRole('button', { name: 'Continue' });
-    userEvent.type(amountInput, '123.45');
+    typeAmount('123.45');
 
     const lhvRadio = screen.getByRole('radio', { name: 'LHV' });
     userEvent.click(lhvRadio);
@@ -169,8 +187,7 @@ describe(SavingsFundPayment, () => {
   it('shows amount in payment details when "Other bank" is selected', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
-    userEvent.type(amountInput, '250');
+    typeAmount('250');
 
     const paymentInfoRadio = screen.getByRole('radio', { name: 'Payment info' });
     userEvent.click(paymentInfoRadio);
@@ -181,8 +198,7 @@ describe(SavingsFundPayment, () => {
   it('hides bank selection and shows manual payment details when amount is 15000 or more', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
-    userEvent.type(amountInput, '15000');
+    typeAmount('15000');
 
     expect(screen.queryByRole('radio', { name: 'LHV' })).not.toBeInTheDocument();
     expect(screen.queryByRole('radio', { name: 'Payment info' })).not.toBeInTheDocument();
@@ -196,8 +212,7 @@ describe(SavingsFundPayment, () => {
   it('shows "Back to account page" link when amount is 15000 or more', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
-    userEvent.type(amountInput, '15000');
+    typeAmount('15000');
 
     expect(await screen.findByText('Did you make the payment?')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Back to account page' })).toHaveAttribute(
@@ -210,8 +225,7 @@ describe(SavingsFundPayment, () => {
   it('shows bank selection when amount is below 15000', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    const amountInput = screen.getByRole('textbox', { name: 'Amount' });
-    userEvent.type(amountInput, '14999');
+    typeAmount('14999');
 
     expect(screen.getByRole('radio', { name: 'LHV' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Payment info' })).toBeInTheDocument();
@@ -245,7 +259,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows step-by-step instructions with a bank link when LHV is selected for recurring', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -259,7 +273,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows a landing-URL link and copy-card when SEB is selected for recurring', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'SEB' }));
 
@@ -275,7 +289,7 @@ describe(SavingsFundPayment, () => {
     it('does not fetch or render recurring details when amount is below minimum', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
       selectRecurring();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '0.5');
+      typeAmount('0.5');
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
       await waitFor(() =>
@@ -287,6 +301,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows recurring details (without amount row) when no amount is entered', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
+      typeAmount('');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -307,7 +322,7 @@ describe(SavingsFundPayment, () => {
       );
 
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -318,7 +333,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows copy-card instead of auto-link for OTHER bank in recurring flow', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'Payment info' }));
 
@@ -329,7 +344,7 @@ describe(SavingsFundPayment, () => {
 
     it('does not render an "Open internet bank" button when Other bank is chosen', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'Payment info' }));
 
@@ -339,7 +354,7 @@ describe(SavingsFundPayment, () => {
 
     it('renders the verify and confirm steps for panel A banks', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -358,7 +373,7 @@ describe(SavingsFundPayment, () => {
       });
 
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'SEB' }));
 
@@ -381,7 +396,7 @@ describe(SavingsFundPayment, () => {
       });
 
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'SEB' }));
 
@@ -414,7 +429,7 @@ describe(SavingsFundPayment, () => {
       );
 
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -444,6 +459,11 @@ describe(SavingsFundPayment, () => {
     it('shows the company account the deposit will go to', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
       expect(screen.getByText('Account: Test Company OÜ')).toBeInTheDocument();
+    });
+
+    it('pre-fills the deposit amount with 250 for a company', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+      expect(getAmountInput()).toHaveValue('250');
     });
 
     it('shows registry code in other bank payment details', async () => {
@@ -494,7 +514,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows company-bank verify step in the recurring panel instead of the investment-account one', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -510,7 +530,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows a copy-card for Swedbank recurring because the business page has no pre-fill', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      userEvent.type(screen.getByRole('textbox', { name: 'Amount' }), '50');
+      typeAmount('50');
       userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
       userEvent.click(screen.getByRole('radio', { name: 'Swedbank' }));
 
@@ -535,6 +555,11 @@ describe(SavingsFundPayment, () => {
 
       initApp();
       history.push('/savings-fund/payment');
+    });
+
+    it('pre-fills the deposit amount with 80 for a child', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+      expect(getAmountInput()).toHaveValue('80');
     });
 
     it('shows the child bank account creditor text instead of the personal one', async () => {

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -37,11 +37,7 @@ describe(SavingsFundPayment, () => {
 
   const getAmountInput = () => screen.getByRole('textbox', { name: 'Amount' });
 
-  // The amount field is pre-filled with a default deposit amount, so replace it
-  // rather than appending. {selectall} selects the default and the typed value
-  // overwrites it in a single call (a bare clear()+type() races the controlled
-  // input's value sync and would append to the default instead).
-  const typeAmount = (value: string) => {
+  const replaceAmount = (value: string) => {
     const amountInput = getAmountInput();
     if (value === '') {
       userEvent.clear(amountInput);
@@ -76,18 +72,18 @@ describe(SavingsFundPayment, () => {
 
     expect(amountInput).toBeInTheDocument();
 
-    // Trigger minimum amount validation (replaces the pre-filled default)
-    typeAmount('0.5');
+    // Trigger minimum amount validation
+    replaceAmount('0.5');
     userEvent.click(submitButton); // Trigger validation
     expect(await screen.findByText(amountValidationMessage)).toBeInTheDocument();
 
     // Trigger required field validation
-    typeAmount('');
+    replaceAmount('');
     userEvent.click(submitButton); // Trigger validation
     expect(await screen.findByText(amountValidationMessage)).toBeInTheDocument();
 
     // Enter valid amount
-    typeAmount('123.45');
+    replaceAmount('123.45');
     userEvent.click(submitButton); // Trigger validation
     expect(amountInput).toHaveValue('123.45');
     await waitFor(() =>
@@ -130,7 +126,7 @@ describe(SavingsFundPayment, () => {
   it('does not show investment account reminder when amount is 15000 or more', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    typeAmount('15000');
+    replaceAmount('15000');
 
     expect(await screen.findByText('Did you make the payment?')).toBeInTheDocument();
     expect(
@@ -142,7 +138,7 @@ describe(SavingsFundPayment, () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
     const submitButton = screen.getByRole('button', { name: 'Continue' });
-    typeAmount('123.45');
+    replaceAmount('123.45');
 
     const lhvRadio = screen.getByRole('radio', { name: 'LHV' });
     userEvent.click(lhvRadio);
@@ -187,7 +183,7 @@ describe(SavingsFundPayment, () => {
   it('shows amount in payment details when "Other bank" is selected', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    typeAmount('250');
+    replaceAmount('250');
 
     const paymentInfoRadio = screen.getByRole('radio', { name: 'Payment info' });
     userEvent.click(paymentInfoRadio);
@@ -198,7 +194,7 @@ describe(SavingsFundPayment, () => {
   it('hides bank selection and shows manual payment details when amount is 15000 or more', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    typeAmount('15000');
+    replaceAmount('15000');
 
     expect(screen.queryByRole('radio', { name: 'LHV' })).not.toBeInTheDocument();
     expect(screen.queryByRole('radio', { name: 'Payment info' })).not.toBeInTheDocument();
@@ -212,7 +208,7 @@ describe(SavingsFundPayment, () => {
   it('shows "Back to account page" link when amount is 15000 or more', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    typeAmount('15000');
+    replaceAmount('15000');
 
     expect(await screen.findByText('Did you make the payment?')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Back to account page' })).toHaveAttribute(
@@ -225,7 +221,7 @@ describe(SavingsFundPayment, () => {
   it('shows bank selection when amount is below 15000', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 
-    typeAmount('14999');
+    replaceAmount('14999');
 
     expect(screen.getByRole('radio', { name: 'LHV' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Payment info' })).toBeInTheDocument();
@@ -259,7 +255,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows step-by-step instructions with a bank link when LHV is selected for recurring', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -273,7 +269,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows a landing-URL link and copy-card when SEB is selected for recurring', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'SEB' }));
 
@@ -289,7 +285,7 @@ describe(SavingsFundPayment, () => {
     it('does not fetch or render recurring details when amount is below minimum', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
       selectRecurring();
-      typeAmount('0.5');
+      replaceAmount('0.5');
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
       await waitFor(() =>
@@ -301,7 +297,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows recurring details (without amount row) when no amount is entered', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('');
+      replaceAmount('');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -322,7 +318,7 @@ describe(SavingsFundPayment, () => {
       );
 
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -333,7 +329,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows copy-card instead of auto-link for OTHER bank in recurring flow', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'Payment info' }));
 
@@ -344,7 +340,7 @@ describe(SavingsFundPayment, () => {
 
     it('does not render an "Open internet bank" button when Other bank is chosen', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'Payment info' }));
 
@@ -354,7 +350,7 @@ describe(SavingsFundPayment, () => {
 
     it('renders the verify and confirm steps for panel A banks', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -373,7 +369,7 @@ describe(SavingsFundPayment, () => {
       });
 
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'SEB' }));
 
@@ -396,7 +392,7 @@ describe(SavingsFundPayment, () => {
       });
 
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'SEB' }));
 
@@ -429,7 +425,7 @@ describe(SavingsFundPayment, () => {
       );
 
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       selectRecurring();
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -514,7 +510,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows company-bank verify step in the recurring panel instead of the investment-account one', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
       userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
 
@@ -530,7 +526,7 @@ describe(SavingsFundPayment, () => {
 
     it('shows a copy-card for Swedbank recurring because the business page has no pre-fill', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
-      typeAmount('50');
+      replaceAmount('50');
       userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
       userEvent.click(screen.getByRole('radio', { name: 'Swedbank' }));
 

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -19,8 +19,6 @@ import { SavingsFundRecurringDetails } from './SavingsFundRecurringDetails';
 const MONTONIO_MAX_AMOUNT = 15000;
 const MIN_RECURRING_AMOUNT = 1;
 
-// Deposit amount pre-filled on the payment page, nudging a meaningful recurring
-// standing order. Children start lower than adults and companies.
 const DEFAULT_AMOUNT = 250;
 const CHILD_DEFAULT_AMOUNT = 80;
 const defaultAmountFor = (accountHolder: AccountHolder): number =>
@@ -49,8 +47,6 @@ export const SavingsFundPayment: FC = () => {
   return <SavingsFundPaymentForm user={user} />;
 };
 
-// Rendered only once the user is loaded, so the pre-filled amount can be derived
-// from who the deposit is for (self/company vs. child).
 const SavingsFundPaymentForm: FC<{ user: User }> = ({ user }) => {
   const [submitError, setSubmitError] = useState(false);
   // Landing here from a "set up a standing order" link opens the recurring option,

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -5,11 +5,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { Link, useLocation } from 'react-router-dom';
 import { redirectToPayment } from '../../../common/api';
 import { useMe } from '../../../common/apiHooks';
-import { PaymentChannel } from '../../../common/apiModels';
+import { PaymentChannel, User } from '../../../common/apiModels';
 import { usePageTitle } from '../../../common/usePageTitle';
 import { PaymentBankButtons } from '../../thirdPillar/ThirdPillarPayment/PaymentBankButtons';
 import { BankKey } from '../../thirdPillar/ThirdPillarPayment/types';
-import { accountHolderFor } from '../accountHolder';
+import { AccountHolder, accountHolderFor } from '../accountHolder';
 import { AmountInput } from '../AmountInput';
 import { InfoSection } from '../InfoSection';
 import { PaymentTypeSelection, SavingsFundPaymentType } from './PaymentTypeSelection';
@@ -18,6 +18,14 @@ import { SavingsFundRecurringDetails } from './SavingsFundRecurringDetails';
 
 const MONTONIO_MAX_AMOUNT = 15000;
 const MIN_RECURRING_AMOUNT = 1;
+
+// Deposit amount pre-filled on the payment page, nudging a meaningful recurring
+// standing order. Children start lower than adults and companies.
+const DEFAULT_AMOUNT = 250;
+const CHILD_DEFAULT_AMOUNT = 80;
+const defaultAmountFor = (accountHolder: AccountHolder): number =>
+  accountHolder === 'child' ? CHILD_DEFAULT_AMOUNT : DEFAULT_AMOUNT;
+
 const RECURRING_BANK_KEYS = ['LHV', 'COOP', 'SWEDBANK', 'SEB', 'LUMINOR', 'OTHER'] as const;
 type RecurringBankKey = (typeof RECURRING_BANK_KEYS)[number];
 const toRecurringBank = (value: string | undefined): RecurringBankKey | null => {
@@ -31,6 +39,19 @@ type IPaymentForm = {
 };
 
 export const SavingsFundPayment: FC = () => {
+  const { data: user } = useMe();
+  usePageTitle('savingsFund.payment.pageTitle');
+
+  if (!user) {
+    return null;
+  }
+
+  return <SavingsFundPaymentForm user={user} />;
+};
+
+// Rendered only once the user is loaded, so the pre-filled amount can be derived
+// from who the deposit is for (self/company vs. child).
+const SavingsFundPaymentForm: FC<{ user: User }> = ({ user }) => {
   const [submitError, setSubmitError] = useState(false);
   // Landing here from a "set up a standing order" link opens the recurring option,
   // the same way the III pillar payment page does.
@@ -38,7 +59,10 @@ export const SavingsFundPayment: FC = () => {
     new URLSearchParams(useLocation().search).get('type') === 'RECURRING' ? 'RECURRING' : 'SINGLE';
   const [paymentType, setPaymentType] = useState<SavingsFundPaymentType>(initialPaymentType);
   const intl = useIntl();
-  const { data: user } = useMe();
+
+  const accountHolder = accountHolderFor(user);
+  const isLegalEntity = accountHolder === 'company';
+
   const {
     handleSubmit,
     control,
@@ -46,7 +70,7 @@ export const SavingsFundPayment: FC = () => {
     formState: { errors, isSubmitting },
   } = useForm<IPaymentForm>({
     defaultValues: {
-      amount: undefined,
+      amount: defaultAmountFor(accountHolder),
       paymentMethod: undefined,
     },
   });
@@ -59,14 +83,6 @@ export const SavingsFundPayment: FC = () => {
   const isRecurring = paymentType === 'RECURRING';
   const recurringBank = isRecurring ? toRecurringBank(paymentMethod) : null;
   const hasValidRecurringAmount = Number.isFinite(amount) && (amount ?? 0) >= MIN_RECURRING_AMOUNT;
-  usePageTitle('savingsFund.payment.pageTitle');
-
-  if (!user) {
-    return null;
-  }
-
-  const accountHolder = accountHolderFor(user);
-  const isLegalEntity = accountHolder === 'company';
 
   const handleRedirect = async (data: IPaymentForm) => {
     try {


### PR DESCRIPTION
## What

The savings-fund (TKF) payment page (`SavingsFundPayment`) left the deposit amount field empty. This pre-fills it with a sensible default so setting up a recurring standing order needs less typing:

- **250 €** for an adult (self) and a company
- **80 €** for a child

The default is derived from `accountHolderFor(user)`.

## Why

Nudges a meaningful recurring contribution instead of starting from a blank field.

## How

- Split `SavingsFundPayment` into a thin loader wrapper + an inner `SavingsFundPaymentForm` that renders only once the user is loaded, so the react-hook-form `defaultValues.amount` can depend on the account holder (a loading-time default can't).
- Added `DEFAULT_AMOUNT` / `CHILD_DEFAULT_AMOUNT` constants + `defaultAmountFor()`.

## Note for review

The amount field is **shared** between single and recurring payments, so this default also pre-fills a single payment. That's the natural reading of "default recurring payment" given the shared field; happy to scope it to the recurring mode only if preferred.

## Tests

- Updated the existing spec: the pre-fill changes the initial value that many tests assumed empty, so amount entry now goes through a `typeAmount` helper (`{selectall}` + type, replacing the default deterministically rather than racing a `clear()`+`type()` on the controlled `CurrencyInput`).
- Added assertions for the defaults: 250 (adult), 250 (company), 80 (child).
- `SavingsFundPayment.spec` 37/37 pass; ESLint clean; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)