### PR TITLE
Name the child on every step of the child onboarding

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/ChildIdentityStep/ChildIdentityStep.test.tsx
@@ -28,7 +28,6 @@ const Wrapper = ({ defaultCode = '' }: { defaultCode?: string }) => {
     mode: 'onBlur',
     defaultValues: {
       childPersonalCode: defaultCode,
-      child: null,
       citizenship: [],
       address: { countryCode: 'EE', street: '', city: '', postalCode: '' },
       email: '',

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.test.tsx
@@ -12,7 +12,6 @@ const Wrapper = () => {
     mode: 'onBlur',
     defaultValues: {
       childPersonalCode: '',
-      child: null,
       citizenship: [],
       address: { countryCode: 'EE', street: '', city: '', postalCode: '' },
       email: '',

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/OnboardingFlowLayout.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/OnboardingFlowLayout.tsx
@@ -11,6 +11,9 @@ interface OnboardingFlowLayoutProps {
   submitting?: boolean;
   nextDisabled?: boolean;
   backDisabled?: boolean;
+  // Who the account is being opened for, kept under the title on every step. The
+  // child flow sets it so the parent never has to remember which child they picked.
+  subtitle?: ReactNode;
   children: ReactNode;
 }
 
@@ -23,6 +26,7 @@ export const OnboardingFlowLayout: FC<OnboardingFlowLayoutProps> = ({
   submitting,
   nextDisabled,
   backDisabled,
+  subtitle,
   children,
 }) => {
   const progressPercentage = (currentStep / totalSteps) * 100;
@@ -43,9 +47,12 @@ export const OnboardingFlowLayout: FC<OnboardingFlowLayoutProps> = ({
             {currentStep}/{totalSteps}
           </span>
         </div>
-        <h1 className="m-0">
-          <FormattedMessage id="flows.savingsFundOnboarding.title" />
-        </h1>
+        <div className="d-flex flex-column gap-1">
+          <h1 className="m-0">
+            <FormattedMessage id="flows.savingsFundOnboarding.title" />
+          </h1>
+          {subtitle ? <p className="m-0 fs-3 text-body-secondary">{subtitle}</p> : null}
+        </div>
       </div>
       {loading ? <Loader /> : children}
       {!loading && (

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/OnboardingFlowLayout.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/OnboardingFlowLayout.tsx
@@ -11,8 +11,6 @@ interface OnboardingFlowLayoutProps {
   submitting?: boolean;
   nextDisabled?: boolean;
   backDisabled?: boolean;
-  // Who the account is being opened for, kept under the title on every step. The
-  // child flow sets it so the parent never has to remember which child they picked.
   subtitle?: ReactNode;
   children: ReactNode;
 }

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/PlannedContributionStep/PlannedContributionStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/PlannedContributionStep/PlannedContributionStep.test.tsx
@@ -12,7 +12,6 @@ const Wrapper = () => {
     mode: 'onBlur',
     defaultValues: {
       childPersonalCode: '',
-      child: null,
       citizenship: [],
       address: { countryCode: 'EE', street: '', city: '', postalCode: '' },
       email: '',

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -100,6 +100,19 @@ describe('SavingsFundChildOnboarding', () => {
     expect(screen.getByText(/Mammu Maasikas/)).toBeInTheDocument();
   });
 
+  it('stops naming the child after going back to the code step', async () => {
+    renderWrapped(<SavingsFundChildOnboarding />);
+    await verifyChild();
+
+    expect(await screen.findByText('2/9')).toBeInTheDocument(); // confirm
+    userEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    // Back on the code step the child is no longer settled — naming the previously
+    // verified one would misidentify whose account is being opened.
+    expect(await screen.findByText('1/9')).toBeInTheDocument();
+    expect(screen.queryByText(/Mammu Maasikas/)).not.toBeInTheDocument();
+  });
+
   it('skips the child selector when arriving from the account switcher and opens on the first question', async () => {
     eligibleChildrenBackend(server, [
       {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -94,8 +94,6 @@ describe('SavingsFundChildOnboarding', () => {
     expect(await screen.findByText('3/9')).toBeInTheDocument(); // residency
     userEvent.click(continueButton());
 
-    // The email step is far enough from the identity step that the parent has lost
-    // track of which child they picked, so the name has to stay on screen.
     expect(await screen.findByText('4/9')).toBeInTheDocument(); // contact
     expect(screen.getByText(/Mammu Maasikas/)).toBeInTheDocument();
   });
@@ -107,8 +105,6 @@ describe('SavingsFundChildOnboarding', () => {
     expect(await screen.findByText('2/9')).toBeInTheDocument(); // confirm
     userEvent.click(screen.getByRole('button', { name: 'Back' }));
 
-    // Back on the code step the child is no longer settled — naming the previously
-    // verified one would misidentify whose account is being opened.
     expect(await screen.findByText('1/9')).toBeInTheDocument();
     expect(screen.queryByText(/Mammu Maasikas/)).not.toBeInTheDocument();
   });
@@ -317,8 +313,7 @@ describe('SavingsFundChildOnboarding', () => {
     );
     userEvent.click(continueButton());
 
-    // Straight to residency — no separate card restating the child's details. The
-    // flow header still names the child, so assert on the card, not the name.
+    // Straight to residency — no separate card restating the child's details.
     expect(await screen.findByText('2/8')).toBeInTheDocument();
     expect(screen.queryByRole('definition')).not.toBeInTheDocument();
   });
@@ -328,7 +323,6 @@ describe('SavingsFundChildOnboarding', () => {
 
     await verifyChild();
 
-    // The header names the child too, so scope the check to the confirm card itself.
     const [nameValue] = await screen.findAllByRole('definition');
     expect(nameValue).toHaveTextContent('Mammu Maasikas');
     expect(screen.getByText(/07\.09\.2015/)).toBeInTheDocument();

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.test.tsx
@@ -84,6 +84,22 @@ describe('SavingsFundChildOnboarding', () => {
     expect(screen.getByLabelText(/personal ID code/i)).toBeInTheDocument();
   });
 
+  it('keeps naming the child on later steps, so the parent can see whose account it is', async () => {
+    renderWrapped(<SavingsFundChildOnboarding />);
+    await verifyChild();
+
+    expect(await screen.findByText('2/9')).toBeInTheDocument(); // confirm
+    userEvent.click(continueButton());
+
+    expect(await screen.findByText('3/9')).toBeInTheDocument(); // residency
+    userEvent.click(continueButton());
+
+    // The email step is far enough from the identity step that the parent has lost
+    // track of which child they picked, so the name has to stay on screen.
+    expect(await screen.findByText('4/9')).toBeInTheDocument(); // contact
+    expect(screen.getByText(/Mammu Maasikas/)).toBeInTheDocument();
+  });
+
   it('skips the child selector when arriving from the account switcher and opens on the first question', async () => {
     eligibleChildrenBackend(server, [
       {
@@ -288,9 +304,10 @@ describe('SavingsFundChildOnboarding', () => {
     );
     userEvent.click(continueButton());
 
-    // Straight to residency — no separate card restating the child's details.
+    // Straight to residency — no separate card restating the child's details. The
+    // flow header still names the child, so assert on the card, not the name.
     expect(await screen.findByText('2/8')).toBeInTheDocument();
-    expect(screen.queryByText(/Mammu Maasikas/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('definition')).not.toBeInTheDocument();
   });
 
   it('confirms a manually entered child from the population register when custody is verified', async () => {
@@ -298,7 +315,9 @@ describe('SavingsFundChildOnboarding', () => {
 
     await verifyChild();
 
-    expect(await screen.findByText(/Mammu Maasikas/)).toBeInTheDocument();
+    // The header names the child too, so scope the check to the confirm card itself.
+    const [nameValue] = await screen.findAllByRole('definition');
+    expect(nameValue).toHaveTextContent('Mammu Maasikas');
     expect(screen.getByText(/07\.09\.2015/)).toBeInTheDocument();
   });
 

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -250,6 +250,9 @@ export const SavingsFundChildOnboarding = () => {
       try {
         setSubmitError(false);
         setChildCodeRejected(false);
+        // This attempt supersedes any previously verified child, so clear it up
+        // front — a rejected code must not leave the earlier name in the header.
+        setValue('child', null);
         const childPersonalCode = getValues('childPersonalCode');
         const response = await createChild({ childPersonalCode });
         if (superseded()) {
@@ -384,6 +387,11 @@ export const SavingsFundChildOnboarding = () => {
     if (activeSection === 0) {
       history.goBack();
       return;
+    }
+    // Going back to the code step unsettles the child: drop the verified one so the
+    // header can't keep naming it while the parent edits or retries the code.
+    if (activeSection === 1) {
+      setValue('child', null);
     }
     setActiveSection((current) => Math.max(current - 1, 0));
     if (submitError) {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -428,6 +428,14 @@ export const SavingsFundChildOnboarding = () => {
         submitting={creatingChild || isFinalizing || verifyingSwitcherPick}
         backDisabled={isFinalizing || verifyingSwitcherPick}
         nextDisabled={isTermsStep && (!termsAccepted || !me?.personalCode)}
+        subtitle={
+          child ? (
+            <FormattedMessage
+              id="flows.savingsFundChildOnboarding.forChild"
+              values={{ name: `${child.firstName} ${child.lastName}`.trim() }}
+            />
+          ) : undefined
+        }
       >
         {verifyingSwitcherPick ? (
           <Loader className="align-middle" />

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -3,7 +3,7 @@ import { Control, useForm } from 'react-hook-form';
 import { useHistory, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import { captureException } from '@sentry/browser';
-import { ChildOnboardingFormData, IdentityFormFields } from './types';
+import { ChildOnboardingFormData, IdentityFormFields, VerifiedChild } from './types';
 import { Loader } from '../../../common';
 import { ChildIdentityStep } from './ChildIdentityStep';
 import { ChildConfirmStep } from './ChildConfirmStep';
@@ -38,7 +38,6 @@ const isChildCodeRejection = (error: unknown): boolean => {
 
 const emptyChildOnboardingForm = (childPersonalCode: string): ChildOnboardingFormData => ({
   childPersonalCode,
-  child: null,
   citizenship: [],
   address: { countryCode: 'EE', street: '', city: '', postalCode: '' },
   email: '',
@@ -69,6 +68,7 @@ export const SavingsFundChildOnboarding = () => {
     arrivedFromSwitcher ? false : null,
   );
   const [verifyingSwitcherPick, setVerifyingSwitcherPick] = useState(arrivedFromSwitcher);
+  const [child, setChild] = useState<VerifiedChild | null>(null);
 
   const { data: me } = useMe();
   const { data: eligibleChildren = [] } = useEligibleChildren();
@@ -81,7 +81,6 @@ export const SavingsFundChildOnboarding = () => {
     defaultValues: emptyChildOnboardingForm(switcherPickedChildCode),
   });
 
-  const child = watch('child');
   const termsAccepted = watch('termsAccepted');
 
   // Once only, and only into empty fields: a /v1/me refetch must not clobber typed contacts.
@@ -250,7 +249,7 @@ export const SavingsFundChildOnboarding = () => {
       try {
         setSubmitError(false);
         setChildCodeRejected(false);
-        setValue('child', null);
+        setChild(null);
         const childPersonalCode = getValues('childPersonalCode');
         const response = await createChild({ childPersonalCode });
         if (superseded()) {
@@ -258,7 +257,7 @@ export const SavingsFundChildOnboarding = () => {
         }
         // A VERIFIED body without a name is malformed — treat it as under review.
         if (response.status === 'VERIFIED' && response.firstName) {
-          setValue('child', {
+          setChild({
             firstName: response.firstName,
             lastName: response.lastName ?? '',
             dateOfBirth: response.dateOfBirth ?? '',
@@ -297,6 +296,7 @@ export const SavingsFundChildOnboarding = () => {
     }
     verifiedSwitcherPickRef.current = switcherPickedChildCode;
     reset(emptyChildOnboardingForm(switcherPickedChildCode));
+    setChild(null);
     contactPrefilledRef.current = false;
     prefillParentContactIfEmpty();
     setManualConfirm(false);
@@ -387,7 +387,7 @@ export const SavingsFundChildOnboarding = () => {
       return;
     }
     if (activeSection === 1) {
-      setValue('child', null);
+      setChild(null);
     }
     setActiveSection((current) => Math.max(current - 1, 0));
     if (submitError) {

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/SavingsFundChildOnboarding.tsx
@@ -250,8 +250,6 @@ export const SavingsFundChildOnboarding = () => {
       try {
         setSubmitError(false);
         setChildCodeRejected(false);
-        // This attempt supersedes any previously verified child, so clear it up
-        // front — a rejected code must not leave the earlier name in the header.
         setValue('child', null);
         const childPersonalCode = getValues('childPersonalCode');
         const response = await createChild({ childPersonalCode });
@@ -388,8 +386,6 @@ export const SavingsFundChildOnboarding = () => {
       history.goBack();
       return;
     }
-    // Going back to the code step unsettles the child: drop the verified one so the
-    // header can't keep naming it while the parent edits or retries the code.
     if (activeSection === 1) {
       setValue('child', null);
     }

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/types.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/types.ts
@@ -64,8 +64,6 @@ export type FundingSourcesValue = FundingSourcesSurveyItem['value'];
 // child (derived backend-side from the population register).
 export interface ChildOnboardingFormData extends SharedOnboardingFields, IdentityFormFields {
   childPersonalCode: string;
-  // Populated once POST /v1/me/children confirms custody (VERIFIED); null until then.
-  child: VerifiedChild | null;
   investmentGoals: InvestmentGoalsMultiValue;
   plannedContribution: PlannedContributionOption | null;
   investableAssets: InvestableAssetsOption | null;

--- a/src/components/flows/savingsAccount/utils.test.ts
+++ b/src/components/flows/savingsAccount/utils.test.ts
@@ -179,7 +179,6 @@ const buildChildFormData = (
   phoneNumber: '+37255555555',
   pepSelfDeclaration: null,
   childPersonalCode: '61509070000',
-  child: { firstName: 'Mammu', lastName: 'Maasikas', dateOfBirth: '2015-09-07' },
   investmentGoals: [{ type: 'OPTION', value: 'EDUCATION' }],
   plannedContribution: 'FROM_200_TO_600',
   investableAssets: 'UP_TO_2000',

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1455,6 +1455,7 @@
   "flows.savingsFundChildOnboarding.assetsStep.over10000": "Over 10 000 €",
   "flows.savingsFundChildOnboarding.assetsStep.description": "Investable assets are immediately available money and investments that can be sold quickly, for example, money in a bank account or deposit, and stocks, bonds, and funds.",
   "flows.savingsFundChildOnboarding.residencyStep.title": "The child’s permanent residence",
+  "flows.savingsFundChildOnboarding.forChild": "For {name}",
 
   "continents.EUROPE": "Europe",
   "continents.ASIA": "Asia",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1545,6 +1545,7 @@
   "flows.savingsFundChildOnboarding.assetsStep.over10000": "Üle 10 000 €",
   "flows.savingsFundChildOnboarding.assetsStep.description": "Investeeritavad varad on kohe kasutatav raha ja investeeringud, mida saab kiiresti müüa, näiteks pangakontol või hoiusel olev raha ning aktsiad, võlakirjad ja fondid.",
   "flows.savingsFundChildOnboarding.residencyStep.title": "Lapse alaline elukoht",
+  "flows.savingsFundChildOnboarding.forChild": "Lapsele {name}",
 
   "continents.EUROPE": "Euroopa",
   "continents.ASIA": "Aasia",


### PR DESCRIPTION
## Problem

Sten spotted this dogfooding the child flow: you pick a child on step 1, and by the email step you have to stop and remember *which* child you picked. Nothing on the later steps names them.

`OnboardingFlowLayout` renders only the generic title ("Opening an Additional Savings Fund") plus a progress bar, and the individual steps only swap their own wording — none of them shows the child.

## Change

Show the child's name under the flow title, on every step of the child flow.

- `OnboardingFlowLayout` gets an optional `subtitle`. The person and company flows pass none and render exactly as before.
- `SavingsFundChildOnboarding` passes the child's name once custody is verified.

The name is already in form state (`child`, set from the `POST /v1/me/children` custody check and already shown on the confirm card), so **no extra API call**.

New keys `flows.savingsFundChildOnboarding.forChild` — EN `For {name}`, ET `Lapsele {name}` — added via `scripts/edit-translation.py` (NBSP counts verified unchanged: en 306, et 315).

## Tests

Written test-first (red → green):

- New: the child is still named at the email step (4/9). Verified failing before the change (`Unable to find text /Mammu Maasikas/`).
- Updated two existing assertions that became ambiguous now the name appears in both header and confirm card. Both re-pointed at the confirm **card** (`role="definition"` / date of birth), which is what they actually meant:
  - "skips the confirm step…" asserted the name was *absent* — that premise is exactly what this PR overturns, so it now asserts the card is absent.
  - "confirms a manually entered child…" now scopes to the card's `<dd>`.

29/29 pass in `SavingsFundChildOnboarding` + `OnboardingFlowLayout`; `tsc --noEmit` clean; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)