### PR TITLE
Offer lapsetoetus as a funding source for a child

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.test.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.test.tsx
@@ -42,6 +42,7 @@ describe('FundingSourcesStep', () => {
     renderWrapped(<Wrapper />);
 
     expect(screen.getByRole('checkbox', { name: /parent.*income/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /child benefit/i })).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: /Gifts/ })).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: /Inheritance/ })).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: /child.*own money/i })).toBeInTheDocument();

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/FundingSourcesStep/FundingSourcesStep.tsx
@@ -15,6 +15,11 @@ const OPTIONS: { id: string; value: FundingSourceOption; labelId: TranslationKey
     labelId: 'flows.savingsFundChildOnboarding.fundingSourcesStep.parentIncome',
   },
   {
+    id: 'funding-child-benefit',
+    value: 'CHILD_BENEFIT',
+    labelId: 'flows.savingsFundChildOnboarding.fundingSourcesStep.childBenefit',
+  },
+  {
     id: 'funding-gifts',
     value: 'GIFTS',
     labelId: 'flows.savingsFundChildOnboarding.fundingSourcesStep.gifts',

--- a/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
+++ b/src/components/flows/savingsAccount/SavingsFundOnboarding/types.api.ts
@@ -51,7 +51,8 @@ export type FundingSourceOption =
   | 'PARENT_INCOME_AND_SAVINGS'
   | 'GIFTS'
   | 'INHERITANCE'
-  | 'CHILD_OWN';
+  | 'CHILD_OWN'
+  | 'CHILD_BENEFIT';
 export type InvestableAssetsOption =
   | 'LESS_THAN_20K'
   | 'RANGE_20K_40K'

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1443,6 +1443,7 @@
   "flows.savingsFundChildOnboarding.fundingSourcesStep.other": "Other",
   "flows.savingsFundChildOnboarding.fundingSourcesStep.other.required": "Enter the source of money",
   "flows.savingsFundChildOnboarding.fundingSourcesStep.otherPlaceholder": "Enter the source of money",
+  "flows.savingsFundChildOnboarding.fundingSourcesStep.childBenefit": "Child benefit",
   "flows.savingsFundChildOnboarding.termsStep.confirmText": "As the child’s legal representative, I confirm that I have reviewed the documents and understand that the investment can both grow and shrink over time.",
   "flows.savingsFundChildOnboarding.contactDetailsStep.description": "By default we use your contact as the child’s representative. If the child has their own email, enter it.",
   "flows.savingsFundChildOnboarding.contactDetailsStep.title": "The child’s contact details",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1533,6 +1533,7 @@
   "flows.savingsFundChildOnboarding.fundingSourcesStep.other": "Muu",
   "flows.savingsFundChildOnboarding.fundingSourcesStep.other.required": "Sisesta raha allikas",
   "flows.savingsFundChildOnboarding.fundingSourcesStep.otherPlaceholder": "Sisesta raha allikas",
+  "flows.savingsFundChildOnboarding.fundingSourcesStep.childBenefit": "Lapsetoetus",
   "flows.savingsFundChildOnboarding.termsStep.confirmText": "Kinnitan lapse seadusliku esindajana, et olen dokumentidega tutvunud ja mõistan, et investeering võib ajas nii kasvada kui kahaneda.",
   "flows.savingsFundChildOnboarding.contactDetailsStep.description": "Vaikimisi kasutame sinu kui esindaja kontakti. Kui lapsel on oma e-post, sisesta see.",
   "flows.savingsFundChildOnboarding.contactDetailsStep.title": "Lapse kontaktandmed",


### PR DESCRIPTION
## Problem

"Kust raha lapse kontole tuleb?" offers parent's income and savings, gifts, inheritance, the child's own money, and free-text other.

**Lapsetoetus is missing** — one of the most common sources of money on a child's account. Parents could only record it by typing into "Muu", which is worse AML data than an enumerated answer.

Spotted by Sten dogfooding the now-launched child flow.

## Change

Adds the option (placed right after the parent's own income, since the benefit is paid to the parent for the child) and the matching `CHILD_BENEFIT` value on `FundingSourceOption`.

Copy: EN `Child benefit`, ET `Lapsetoetus` — added via `scripts/edit-translation.py`. NBSP counts verified unchanged (en 306, et 315).

## ⚠️ Merge order — backend first

Depends on **TulevaEE/onboarding-service#1800**, which adds `CHILD_BENEFIT` to the `FundingSource` enum.

**Do not merge/deploy this before that is live**, or selecting the new option fails survey deserialization. Kept as a draft for that reason.

## Tests

Written test-first: the new checkbox assertion was verified failing (`Unable to find an accessible element with the role "checkbox" and name /child benefit/i`) before the option existed.

`FundingSourcesStep` 4/4, `SavingsFundChildOnboarding` 18/18, `tsc --noEmit` clean, ESLint clean.

## Compliance note

✅ **Signed off by Maria** — the wording is approved (confirmed by Sten, 2026-07-22).

This changes a regulated AML/KYC questionnaire on a **live** flow, so it needed that sign-off before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
