### PR TITLE
Keep a cleared deposit amount empty instead of restoring the default

### DIFF
--- a/src/components/common/input/CurrencyInput.tsx
+++ b/src/components/common/input/CurrencyInput.tsx
@@ -4,7 +4,7 @@ import styles from './CurrencyInput.module.scss';
 
 type CurrencyInputProps = {
   id?: string;
-  value: number | undefined;
+  value: number | null | undefined;
   onChange: (value: number | undefined) => void;
   error?: boolean;
   placeholder?: string;

--- a/src/components/flows/savingsAccount/AmountInput/AmountInput.tsx
+++ b/src/components/flows/savingsAccount/AmountInput/AmountInput.tsx
@@ -46,7 +46,9 @@ export function AmountInput<T extends FieldValues>({
             <CurrencyInput
               id={inputId}
               value={field.value}
-              onChange={field.onChange}
+              // An undefined value makes react-hook-form fall back to the field's
+              // default, so a cleared input would repopulate; null is kept as-is.
+              onChange={(value) => field.onChange(value ?? null)}
               error={!!fieldState.error}
               max={max}
             />

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundOtherBankDetails.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundOtherBankDetails.tsx
@@ -8,7 +8,7 @@ const ACCOUNT_NAME = 'Tuleva Täiendav Kogumisfond';
 const ACCOUNT_NUMBER = 'EE711010220306707220';
 
 export const SavingsFundOtherBankDetails: FC<{
-  amount: number | undefined;
+  amount: number | null | undefined;
   personalCode: string;
   titleId?: TranslationKey;
 }> = ({ amount, personalCode, titleId = 'savingsFund.payment.otherBank.title' }) => (

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -62,6 +62,14 @@ describe(SavingsFundPayment, () => {
     expect(getAmountInput()).toHaveValue('250');
   });
 
+  it('stays empty when the pre-filled amount is deleted', async () => {
+    expect(await findPageHeading()).toBeInTheDocument();
+
+    replaceAmount('');
+
+    expect(getAmountInput()).toHaveValue('');
+  });
+
   it('validates the deposit amount and bank selection', async () => {
     expect(await findPageHeading()).toBeInTheDocument();
 

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -32,7 +32,7 @@ const toRecurringBank = (value: string | undefined): RecurringBankKey | null => 
 };
 
 type IPaymentForm = {
-  amount: number | undefined;
+  amount: number | null;
   paymentMethod: BankKey | 'other';
 };
 
@@ -85,7 +85,7 @@ const SavingsFundPaymentForm: FC<{ user: User }> = ({ user }) => {
       setSubmitError(false);
       await redirectToPayment({
         recipientPersonalCode: user.role.code,
-        amount: data.amount,
+        amount: data.amount ?? undefined,
         currency: 'EUR',
         type: 'SAVINGS',
         paymentChannel: data.paymentMethod?.toUpperCase() as PaymentChannel,

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
@@ -51,7 +51,7 @@ const isSafeBankUrl = (url: string | undefined): url is string => {
 
 type Props = {
   bank: BankKey;
-  amount: number | undefined;
+  amount: number | null | undefined;
   personalCode: string;
   isLegalEntity: boolean;
 };
@@ -76,7 +76,7 @@ export const SavingsFundRecurringDetails: FC<Props> = ({
         type: 'SAVINGS_RECURRING',
         ...(meta.channel ? { paymentChannel: meta.channel } : {}),
         recipientPersonalCode: personalCode,
-        ...(hasAmount ? { amount } : {}),
+        ...(hasAmount ? { amount: amount ?? undefined } : {}),
         currency: 'EUR',
       }),
     enabled: !!personalCode,

--- a/src/components/flows/savingsAccount/SavingsFundWithdraw/SavingsFundWithdraw.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundWithdraw/SavingsFundWithdraw.tsx
@@ -16,7 +16,7 @@ import { InfoSection } from '../InfoSection';
 import Card from '../../../common/card';
 import { Euro } from '../../../common/Euro';
 
-const parseAmount = (value: string | number | undefined): number => {
+const parseAmount = (value: string | number | null | undefined): number => {
   if (!value) {
     return 0;
   }
@@ -26,7 +26,7 @@ const parseAmount = (value: string | number | undefined): number => {
 };
 
 type IWithdrawalForm = {
-  amount: number | undefined;
+  amount: number | null;
   iban: string;
 };
 
@@ -48,7 +48,7 @@ export const SavingsFundWithdraw: FC = () => {
   } = useForm<IWithdrawalForm>({
     mode: 'onChange',
     defaultValues: {
-      amount: undefined,
+      amount: null,
       iban: '',
     },
   });


### PR DESCRIPTION
## Problem

The savings-fund deposit amount is pre-filled with a default (250 €, or 80 € for a child). Deleting the last character of the amount made the default pop right back, so the pre-fill could not be replaced by first clearing the field. The form was also split-brained: the input displayed 250 while the form internally held `undefined` and failed required-validation.

## Cause

`CurrencyInput` reports an emptied field as `onChange(undefined)`, and react-hook-form treats `undefined` as "fall back to `defaultValues`" when rendering a controlled field.

## Fix

`AmountInput` now reports a cleared field as `null` at the form boundary — a value react-hook-form keeps — so the deletion sticks and required-validation still fires on submit. The `amount` fields and their consumers are typed `number | null` accordingly. Runtime behavior of the consumers was already null-safe.

Covered by a new spec: clearing the pre-filled amount leaves the input empty.

https://claude.ai/code/session_01WuyxW7HqxwQ2vfuoGcfQTT