### PR TITLE
Show child-specific verify step in the recurring savings payment panel

### DIFF
--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.spec.tsx
@@ -585,6 +585,24 @@ describe(SavingsFundPayment, () => {
       ).not.toBeInTheDocument();
     });
 
+    it('shows the child-bank verify step in the recurring panel instead of the investment-account one', async () => {
+      expect(await findPageHeading()).toBeInTheDocument();
+      replaceAmount('50');
+      userEvent.click(screen.getByRole('radio', { name: 'Recurring payment' }));
+      userEvent.click(screen.getByRole('radio', { name: 'LHV' }));
+
+      expect(
+        await screen.findByRole('heading', { name: 'Set up the recurring payment in LHV' }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/paying from/i)).toBeInTheDocument();
+      expect(screen.getByText(/then confirm the standing order/i)).toBeInTheDocument();
+      // Once in the info section at the top, once as the bold chunk of step 3.
+      expect(screen.getAllByText(/your or the child’s bank account/)).toHaveLength(2);
+      // The self variant of the step ("…paying from an investment account") must not appear.
+      expect(screen.queryByText(/paying from an/i)).not.toBeInTheDocument();
+    });
+
     it('does not show the investment account reminder, even after a bank is selected', async () => {
       expect(await findPageHeading()).toBeInTheDocument();
 

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundPayment.tsx
@@ -57,7 +57,6 @@ const SavingsFundPaymentForm: FC<{ user: User }> = ({ user }) => {
   const intl = useIntl();
 
   const accountHolder = accountHolderFor(user);
-  const isLegalEntity = accountHolder === 'company';
 
   const {
     handleSubmit,
@@ -183,7 +182,7 @@ const SavingsFundPaymentForm: FC<{ user: User }> = ({ user }) => {
               bank={recurringBank}
               amount={amount}
               personalCode={user.role.code}
-              isLegalEntity={isLegalEntity}
+              accountHolder={accountHolder}
             />
           ) : null}
 

--- a/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
+++ b/src/components/flows/savingsAccount/SavingsFundPayment/SavingsFundRecurringDetails.tsx
@@ -8,6 +8,7 @@ import { PaymentDetailRow } from '../../thirdPillar/ThirdPillarPayment/paymentDe
 import { PaymentStep } from '../../common/PaymentStep/PaymentStep';
 import { CopyButton } from '../../../common/CopyButton';
 import { formatAmountForCount, formatAmountForCurrency } from '../../../common/utils';
+import { AccountHolder } from '../accountHolder';
 
 export type BankKey = 'LHV' | 'COOP' | 'SWEDBANK' | 'SEB' | 'LUMINOR' | 'OTHER';
 
@@ -53,21 +54,27 @@ type Props = {
   bank: BankKey;
   amount: number | null | undefined;
   personalCode: string;
-  isLegalEntity: boolean;
+  accountHolder: AccountHolder;
 };
+
+const VERIFY_STEP_MESSAGE_IDS = {
+  self: 'savingsFund.recurring.step.verify',
+  company: 'savingsFund.recurring.step.verify.legalEntity',
+  child: 'savingsFund.recurring.step.verify.child',
+} as const;
 
 export const SavingsFundRecurringDetails: FC<Props> = ({
   bank,
   amount,
   personalCode,
-  isLegalEntity,
+  accountHolder,
 }) => {
   const meta = BANK_META[bank];
   // Swedbank only pre-fills the private standing-order form. Legal entities are
   // sent to the business page, which has no pre-fill, so they copy the fields
   // manually like any other LANDING bank.
   const linkBehavior: LinkBehavior =
-    bank === 'SWEDBANK' && isLegalEntity ? 'LANDING' : meta.linkBehavior;
+    bank === 'SWEDBANK' && accountHolder === 'company' ? 'LANDING' : meta.linkBehavior;
   const hasAmount = Number.isFinite(amount) && (amount ?? 0) >= 1;
   const { data, isLoading, isFetching, isError } = useQuery<PaymentLink>({
     queryKey: ['paymentLink', 'SAVINGS_RECURRING', meta.channel ?? null, amount, personalCode],
@@ -153,11 +160,7 @@ export const SavingsFundRecurringDetails: FC<Props> = ({
 
           <PaymentStep number={3}>
             <FormattedMessage
-              id={
-                isLegalEntity
-                  ? 'savingsFund.recurring.step.verify.legalEntity'
-                  : 'savingsFund.recurring.step.verify'
-              }
+              id={VERIFY_STEP_MESSAGE_IDS[accountHolder]}
               values={{
                 b: (chunks: string) => <b>{chunks}</b>,
               }}

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1262,6 +1262,7 @@
   "savingsFund.recurring.step.review": "Check the details",
   "savingsFund.recurring.step.verify": "Make sure you're paying from an <b>investment account</b>, then confirm the standing order",
   "savingsFund.recurring.step.verify.legalEntity": "Make sure you're paying from the <b>company's bank account</b>, then confirm the standing order",
+  "savingsFund.recurring.step.verify.child": "Make sure you're paying from <b>your or the child’s bank account</b>, then confirm the standing order",
   "savingsFund.recurring.copyCard.recipientName": "Recipient name",
   "savingsFund.recurring.copyCard.recipientIban": "Recipient account (IBAN)",
   "savingsFund.recurring.copyCard.description": "Description",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1352,6 +1352,7 @@
   "savingsFund.recurring.step.review": "Kontrolli andmed üle",
   "savingsFund.recurring.step.verify": "Veendu, et maksad <b>investeerimiskontolt</b>, ja kinnita püsimakse",
   "savingsFund.recurring.step.verify.legalEntity": "Veendu, et maksad <b>osaühingu pangakontolt</b>, ja kinnita püsimakse",
+  "savingsFund.recurring.step.verify.child": "Veendu, et maksad <b>enda või lapse pangakontolt</b>, ja kinnita püsimakse",
   "savingsFund.recurring.copyCard.recipientName": "Saaja nimi",
   "savingsFund.recurring.copyCard.recipientIban": "Kontonumber",
   "savingsFund.recurring.copyCard.description": "Selgitus",


### PR DESCRIPTION
## Problem

Member feedback on the savings fund (Täiendav Kogumisfond) payment flow: the recurring-payment instructions were contradictory. When paying for a child, the info section at the top says *"Don't use your own investment account for the child's deposit"* — but step 3 of the standing-order panel said *"Make sure you're paying from an **investment account**, then confirm the standing order"*.

The verify step (`SavingsFundRecurringDetails`) only distinguished legal entities from everyone else, so child accounts fell through to the adult investment-account copy.

## Fix

- Replace the `isLegalEntity: boolean` prop with the existing `AccountHolder` union (`'self' | 'company' | 'child'`), resolving the step-3 message id through a lookup map — one prop, no bogus states.
- Add `savingsFund.recurring.step.verify.child` (et/en) matching the info-section wording: *"Veendu, et maksad **enda või lapse pangakontolt**, ja kinnita püsimakse"* / *"Make sure you're paying from **your or the child's bank account**, then confirm the standing order"*.
- Translations edited via `scripts/edit-translation.py` only (NBSPs untouched).

No behavior change for self or company: same message ids render as before, and the Swedbank business-page LANDING special case now keys on `accountHolder === 'company'`, which is the same condition.

## Tests

TDD: added a failing test in the "when representing a child" block asserting the child verify step renders and the investment-account variant does not, then made it green. Full savingsAccount suite: 35 suites / 308 tests passing; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)