### PR TITLE
Make the header account switcher look like a control

### DIFF
--- a/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.test.tsx
+++ b/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.test.tsx
@@ -123,6 +123,37 @@ describe('RoleSwitcher', () => {
     });
   });
 
+  describe('as a control people can recognise', () => {
+    it('names the toggle as an account menu rather than only the account holder', async () => {
+      rolesBackend(server, [personalRole]);
+      userBackend(server, { role: personalRole });
+
+      renderRoleSwitcher();
+
+      expect(await screen.findByRole('button', { name: /account menu/i })).toBeInTheDocument();
+    });
+
+    it('marks the toggle with a person icon while acting as yourself', async () => {
+      rolesBackend(server, multipleRoles);
+      userBackend(server, { role: personalRole });
+
+      renderRoleSwitcher();
+
+      expect(await screen.findByTestId('role-icon-person')).toBeInTheDocument();
+      expect(screen.queryByTestId('role-icon-legal-entity')).not.toBeInTheDocument();
+    });
+
+    it('swaps to a company icon while acting as a company', async () => {
+      rolesBackend(server, multipleRoles);
+      userBackend(server, { role: companyRole });
+
+      renderRoleSwitcher();
+
+      expect(await screen.findByTestId('role-icon-legal-entity')).toBeInTheDocument();
+      expect(screen.queryByTestId('role-icon-person')).not.toBeInTheDocument();
+    });
+  });
+
   describe('with a child the other parent is onboarding', () => {
     const pendingChild = { type: 'PERSON' as const, code: '61506150006', name: 'Mari Maasikas' };
 

--- a/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.tsx
+++ b/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.tsx
@@ -146,11 +146,13 @@ export const RoleSwitcher = ({ userName, onRoleSwitch }: Props) => {
     <span className="dropdown d-inline-block" ref={containerRef} onBlur={handleBlur}>
       {/* Bordered rather than a bare link: a name with only a chevron reads as a
           label, so nobody discovers that account switching and "open a new account"
-          live behind it. */}
+          live behind it. Primary (brand blue) rather than secondary grey, which read
+          as disabled next to the header's blue links; the pill shape keeps it from
+          looking like a disabled form field. */}
       <button
         ref={toggleRef}
         type="button"
-        className="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2"
+        className="btn btn-outline-primary btn-sm rounded-pill d-inline-flex align-items-center gap-2"
         aria-expanded={open}
         onClick={() => setOpen(!open)}
         onKeyDown={handleKeyDown}

--- a/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.tsx
+++ b/src/components/LoggedInApp/header/roleSwitcher/RoleSwitcher.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { useMe, usePendingOnboardings, useRoles, useSwitchRole } from '../../../common/apiHooks';
-import { SwitchRoleCommand } from '../../../common/apiModels';
+import { RoleType, SwitchRoleCommand } from '../../../common/apiModels';
 import {
   isChildOnboardingEnabled,
   isCompanyOnboardingEnabled,
@@ -15,6 +15,39 @@ type Props = {
 
 const dropdownItemsOf = (container: HTMLElement | null): HTMLElement[] =>
   Array.from(container?.querySelectorAll<HTMLElement>('.dropdown-item') ?? []);
+
+// Phosphor Icons, bold weight (MIT) — the same user/briefcase pair the savings-fund
+// onboarding chooser uses for its person and company cards. Decorative: the button
+// already says whose account this is, so they stay out of the accessible name.
+// A represented child is a PERSON role too, and shares the person icon.
+const roleIcons: Record<RoleType, ReactNode> = {
+  PERSON: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 256 256"
+      aria-hidden="true"
+      data-testid="role-icon-person"
+    >
+      <path d="M234.38,210a123.36,123.36,0,0,0-60.78-53.23,76,76,0,1,0-91.2,0A123.36,123.36,0,0,0,21.62,210a12,12,0,1,0,20.77,12c18.12-31.32,50.12-50,85.61-50s67.49,18.69,85.61,50a12,12,0,0,0,20.77-12ZM76,96a52,52,0,1,1,52,52A52.06,52.06,0,0,1,76,96Z" />
+    </svg>
+  ),
+  LEGAL_ENTITY: (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 256 256"
+      aria-hidden="true"
+      data-testid="role-icon-legal-entity"
+    >
+      <path d="M100,100a12,12,0,0,1,12-12h32a12,12,0,0,1,0,24H112A12,12,0,0,1,100,100ZM236,68V196a20,20,0,0,1-20,20H40a20,20,0,0,1-20-20V68A20,20,0,0,1,40,48H76V40a28,28,0,0,1,28-28h48a28,28,0,0,1,28,28v8h36A20,20,0,0,1,236,68ZM100,48h56V40a4,4,0,0,0-4-4H104a4,4,0,0,0-4,4ZM44,72v35.23A180.06,180.06,0,0,0,128,128a180,180,0,0,0,84-20.78V72ZM212,192V133.94A204.27,204.27,0,0,1,128,152a204.21,204.21,0,0,1-84-18.06V192Z" />
+    </svg>
+  ),
+};
 
 export const RoleSwitcher = ({ userName, onRoleSwitch }: Props) => {
   const { data: roles } = useRoles();
@@ -111,21 +144,30 @@ export const RoleSwitcher = ({ userName, onRoleSwitch }: Props) => {
 
   return (
     <span className="dropdown d-inline-block" ref={containerRef} onBlur={handleBlur}>
+      {/* Bordered rather than a bare link: a name with only a chevron reads as a
+          label, so nobody discovers that account switching and "open a new account"
+          live behind it. */}
       <button
         ref={toggleRef}
         type="button"
-        className="btn btn-link p-0 border-0 d-inline-flex align-items-center gap-1"
+        className="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2"
         aria-expanded={open}
         onClick={() => setOpen(!open)}
         onKeyDown={handleKeyDown}
       >
+        {roleIcons[user?.role?.type ?? 'PERSON']}
         {displayName}
+        {/* Screen readers otherwise hear only a name, with no hint it opens anything. */}
+        <span className="visually-hidden">
+          <FormattedMessage id="roleSwitcher.accountMenu" />
+        </span>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
           fill="currentColor"
           viewBox="0 0 16 16"
+          aria-hidden="true"
         >
           <path
             fillRule="evenodd"

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -242,6 +242,7 @@
   "id.card.signature.session.not.found": "ID-card session is expired. Please log in again.",
   "header.my.account": "My account",
   "roleSwitcher.openNewAccount": "Open a new account",
+  "roleSwitcher.accountMenu": "account menu",
   "account.member.statement": "You are Tuleva member no. {memberNumber}",
   "account.member.statement.comment": "Since {memberJoinDate}, you earn a 0.05% annual membership bonus",
   "account.member.statement.comment.amount": "In {year}, you earned a membership bonus of {amount}",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -252,6 +252,7 @@
   "id.card.signature.session.not.found": "ID-kaardi sessioon on aegunud, palun logi uuesti sisse.",
   "header.my.account": "Minu konto",
   "roleSwitcher.openNewAccount": "Ava uus konto",
+  "roleSwitcher.accountMenu": "kontode menüü",
   "account.member.statement": "Sa oled Tuleva liige nr {memberNumber}",
   "account.member.statement.comment": "Alates {memberJoinDate} teenid Tulevasse toodud raha pealt liikmeboonust 0.05% aastas",
   "account.member.statement.comment.amount": "{year}. aastal teenisid liikmeboonust {amount}",


### PR DESCRIPTION
## Why

The account switcher in the header is the **only** way to reach account switching and
**"Open a new account"** — the entry point to the savings-fund flows for a child and for an
osaühing. Today it renders as the bare account name followed by a small chevron:

```
Sten Andreas Ehrlich ⌄     Väljun
```

It is a blue link, so it does look clickable — but nothing says it opens a *menu of accounts*,
so people don't try it and the child/osaühing flows stay effectively undiscoverable.

There is a related gap worth knowing about: the savings-fund status box on the account page
does link to the chooser via "Alustan kogumist", but that CTA flips to "Teen sissemakse" once
your own onboarding is `COMPLETED`. After you open your own TKF account, the chooser becomes
unreachable from the account page entirely — which is exactly the group most likely to open a
second account. **This PR does not address that**; it only fixes the header control.

## What changed

- The toggle becomes a **brand-blue outline pill** (`btn-outline-primary btn-sm rounded-pill`)
  so it reads as a control rather than a label.
- A leading icon for the role being acted as — person or briefcase — so the header also answers
  "whose account am I looking at?" at a glance. Same Phosphor icon pair the savings-fund
  onboarding chooser already uses for its person and company cards.
- Accessibility: the button's accessible name was just the account holder's name, so a screen
  reader announced "Sten Andreas Ehrlich, button" with no hint it opens anything. Added a
  visually hidden "account menu" / "kontode menüü", and marked the decorative chevron
  `aria-hidden`. Verified in a real browser: the a11y tree reads `[button] "Test OÜ kontode menüü"`.

**Nothing on the account page itself changes.** The dropdown contents, keyboard navigation, and
role-switching behaviour are untouched.

Styling note: this first went up as `btn-outline-secondary` (Bootstrap grey). Rendered next to the
header's blue links it read as *disabled* and off-brand, and a square bordered box looked like a
disabled form field. Blue plus a pill shape fixes both.

## Questions you might have

- **Why a `data-testid` on the icons instead of a semantic query?** The icons are decorative and
  deliberately `aria-hidden`, so there is no role or accessible name to query. This follows the
  existing precedent for icon variants in `StatusBoxRow` (`status-icon-success`, `status-icon-todo`,
  …), which `PersonAccountPageView.test.tsx` already asserts on the same way. Giving them an
  `aria-label` purely to make them queryable would add noise to every screen-reader announcement.
- **Why does a represented child get the person icon?** A child role is a `PERSON` role, so it
  shares the person icon. The chooser has a third (balloon) icon, but distinguishing a child would
  mean comparing `role.code` against the user's own `personalCode`, and I'd rather not add that
  branch until someone asks for it. Noted in a code comment.
- **Icons are keyed by `RoleType` in a `Record`**, not by booleans, so a future role type is a
  compile error rather than a silently missing icon.

## Known, pre-existing: narrow screens

At 390px with a long company name, "Väljun" wraps onto a second line. **This already happens on
master** — the header row is simply too tight for logo + long name + logout. The bordered toggle is
wider than the bare link, so it makes an existing condition slightly worse (measured at +23–36px
depending on name length). Short names do not wrap either before or after.

I tried capping the name with `text-truncate` and removed it again: at any sensible max-width it
never engages, because the long name is only 171px and the overflow comes from the row's total
width, not the name. A real fix is the header's responsive layout, which felt out of scope here —
happy to do it as a follow-up if you'd rather it ship together.

## Testing

Strict TDD — the three new tests were written first and observed failing, then made to pass:

- the toggle is reachable as an "account menu", not only by the holder's name
- a person icon while acting as yourself
- a company icon while acting as a company

They assert behaviour, not class names, so the restyle above needed no test changes.

`RoleSwitcher.test.tsx` 22/22, and the 16 change-adjacent suites (Header, LoggedInApp, AccountPage,
PersonAccountPageView, RepresentedPartyAccountPage, statusBox) 130/130 with 29 snapshots. `tsc
--noEmit` clean, `eslint --max-warnings=0` clean via the pre-commit hook. Also verified running
against the real backend via `npm run develop-production`.

Note on the full suite: it has ~18 failing suites on **pristine `origin/master`** locally (timeouts
under parallel load — suites taking 54–175s). CircleCI's `test` job is green on this branch, so
nothing here is caused by this change.

Translations were edited with `scripts/edit-translation.py`, so the intentional NBSPs are intact
(diff is exactly one added line per file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
