### PR TITLE
Show what the register holds as the portfolio's closing value

### DIFF
--- a/src/components/account/Portfolio/PeriodSelector.tsx
+++ b/src/components/account/Portfolio/PeriodSelector.tsx
@@ -80,7 +80,7 @@ const DateInput: React.FunctionComponent<{
       key={discarded}
       type="date"
       aria-label={label}
-      className="form-control form-control-sm w-auto"
+      className="form-control form-control-sm w-auto flex-fill"
       value={typed ?? value}
       min={min}
       max={max}
@@ -148,21 +148,28 @@ export const PeriodSelector: React.FunctionComponent<{
 
   return (
     <>
-      <div className="d-flex flex-wrap gap-2 align-items-center mb-3">
+      {/* On a phone the label takes its own line and the pills wrap as one group under
+          it. Left in a single row they break wherever they run out of width, which puts
+          the label on one line and the buttons in a staircase down the card. */}
+      <div className="d-flex flex-column flex-sm-row flex-wrap align-items-start align-items-sm-center gap-2 mb-3">
         <span className="text-body-secondary me-1">
           <FormattedMessage id="savingsFund.statement.period.label" />
         </span>
-        {presets.map((preset) => (
-          <PillButton
-            key={preset.id}
-            selected={from === preset.from && to === preset.to}
-            onClick={() => onPeriodChange(preset.from, preset.to)}
-          >
-            {preset.label}
-          </PillButton>
-        ))}
+        <div className="d-flex flex-wrap gap-2">
+          {presets.map((preset) => (
+            <PillButton
+              key={preset.id}
+              selected={from === preset.from && to === preset.to}
+              onClick={() => onPeriodChange(preset.from, preset.to)}
+            >
+              {preset.label}
+            </PillButton>
+          ))}
+        </div>
       </div>
 
+      {/* A date box is as wide as the date it holds, so on a narrow screen the two of
+          them share the row rather than pushing the second one off the card. */}
       <div className="d-flex flex-wrap gap-2 align-items-center">
         <DateInput
           label="from"

--- a/src/components/account/Portfolio/PortfolioPage.test.tsx
+++ b/src/components/account/Portfolio/PortfolioPage.test.tsx
@@ -7,8 +7,9 @@ import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { createDefaultStore, login, renderWrapped } from '../../../test/utils';
+import { userBackend } from '../../../test/backend';
 import { initializeConfiguration } from '../../config/config';
-import { Portfolio } from '../../common/apiModels';
+import { Portfolio, RoleType } from '../../common/apiModels';
 import { PortfolioPage } from './PortfolioPage';
 
 const allTime: Portfolio = {
@@ -116,15 +117,31 @@ const portfolioBackendRefusingNarrowedPeriods = () =>
     ),
   );
 
+const statementRequests: string[] = [];
+
 const registerHolding = (funds: unknown[], savingsFund: unknown | null) =>
+  server.use(
+    rest.get('http://localhost/v1/pension-account-statement', (req, res, ctx) => {
+      statementRequests.push(req.url.pathname);
+      return res(ctx.json(funds));
+    }),
+    rest.get('http://localhost/v1/savings-account-statement', (req, res, ctx) =>
+      res(ctx.json(savingsFund)),
+    ),
+  );
+
+const registerRefusingTheSavingsBalance = (funds: unknown[]) =>
   server.use(
     rest.get('http://localhost/v1/pension-account-statement', (req, res, ctx) =>
       res(ctx.json(funds)),
     ),
     rest.get('http://localhost/v1/savings-account-statement', (req, res, ctx) =>
-      res(ctx.json(savingsFund)),
+      res(ctx.status(500), ctx.json({})),
     ),
   );
+
+const actingFor = (roleType: RoleType) =>
+  userBackend(server, { role: { type: roleType, code: '90000000', name: 'Acme' } });
 
 const portfolioBackendDown = () =>
   server.use(
@@ -153,8 +170,10 @@ afterAll(() => server.close());
 beforeEach(() => {
   initializeConfiguration();
   requestedPeriods.length = 0;
+  statementRequests.length = 0;
   portfolioBackend();
   registerHolding([], null);
+  actingFor('PERSON');
 });
 
 describe('what the register holds today', () => {
@@ -177,6 +196,27 @@ describe('what the register holds today', () => {
 
     expect(await screen.findAllByText(/600[.,]00/)).not.toHaveLength(0);
     expect(screen.queryByText(/899[.,]00/)).not.toBeInTheDocument();
+  });
+
+  it('waits for the whole register answer rather than mixing it with rebuilt values', async () => {
+    registerRefusingTheSavingsBalance([fundBalance(2, 700, 77)]);
+    initializeComponent();
+
+    // 200 savings fund + 300 II pillar, the values the prices rebuilt: a balance for one
+    // band and a rebuilt value for the other would add up to a total from neither source.
+    expect(await screen.findAllByText(/500[.,]00/)).not.toHaveLength(0);
+    expect(screen.queryByText(/1[\s ]?077[.,]00/)).not.toBeInTheDocument();
+  });
+
+  it('does not ask the pension register about a company', async () => {
+    actingFor('LEGAL_ENTITY');
+    registerHolding([fundBalance(2, 700, 77)], fundBalance(null, 111, 11));
+    initializeComponent();
+
+    // 122 in the savings fund the company does hold, on top of the 300 the prices
+    // rebuilt; a company holds no pillar, so the register is never asked about one.
+    expect(await screen.findAllByText(/422[.,]00/)).not.toHaveLength(0);
+    expect(statementRequests).toHaveLength(0);
   });
 
   it('leaves a pillar the register says nothing about on its rebuilt value', async () => {

--- a/src/components/account/Portfolio/PortfolioPage.test.tsx
+++ b/src/components/account/Portfolio/PortfolioPage.test.tsx
@@ -73,6 +73,25 @@ const lastYear: Portfolio = {
   ],
 };
 
+const fundBalance = (pillar: number | null, value: number, unavailableValue: number) => ({
+  fund: {
+    isin: `EE${pillar}${value}`,
+    name: `Fund ${pillar}`,
+    fundManager: { name: 'Tuleva' },
+    managementFeeRate: 0.0034,
+    pillar,
+    ongoingChargesFigure: 0.0039,
+  },
+  value,
+  unavailableValue,
+  currency: 'EUR',
+  activeContributions: true,
+  contributions: 0,
+  subtractions: 0,
+  profit: 0,
+  units: 1,
+});
+
 const server = setupServer();
 
 const requestedPeriods: { from: string | null; to: string | null }[] = [];
@@ -94,6 +113,16 @@ const portfolioBackendRefusingNarrowedPeriods = () =>
       req.url.searchParams.get('from')
         ? res(ctx.status(500), ctx.json({}))
         : res(ctx.json(allTime)),
+    ),
+  );
+
+const registerHolding = (funds: unknown[], savingsFund: unknown | null) =>
+  server.use(
+    rest.get('http://localhost/v1/pension-account-statement', (req, res, ctx) =>
+      res(ctx.json(funds)),
+    ),
+    rest.get('http://localhost/v1/savings-account-statement', (req, res, ctx) =>
+      res(ctx.json(savingsFund)),
     ),
   );
 
@@ -125,6 +154,37 @@ beforeEach(() => {
   initializeConfiguration();
   requestedPeriods.length = 0;
   portfolioBackend();
+  registerHolding([], null);
+});
+
+describe('what the register holds today', () => {
+  it('is the closing value of a period that runs to today', async () => {
+    registerHolding([fundBalance(2, 700, 77)], fundBalance(null, 111, 11));
+    initializeComponent();
+
+    // 777 in the II pillar and 122 in the savings fund, rather than the 500 the
+    // published prices rebuild from units alone.
+    expect(await screen.findAllByText(/899[.,]00/)).not.toHaveLength(0);
+  });
+
+  it('is left out of a period that ended before today', async () => {
+    registerHolding([fundBalance(2, 700, 77)], fundBalance(null, 111, 11));
+    initializeComponent();
+
+    expect(await screen.findAllByText(/899[.,]00/)).not.toHaveLength(0);
+
+    userEvent.click(screen.getByRole('button', { name: 'Last year' }));
+
+    expect(await screen.findAllByText(/600[.,]00/)).not.toHaveLength(0);
+    expect(screen.queryByText(/899[.,]00/)).not.toBeInTheDocument();
+  });
+
+  it('leaves a pillar the register says nothing about on its rebuilt value', async () => {
+    registerHolding([fundBalance(3, 900, 0)], null);
+    initializeComponent();
+
+    expect(await screen.findAllByText(/500[.,]00/)).not.toHaveLength(0);
+  });
 });
 
 describe('a portfolio the backend has not answered with yet', () => {

--- a/src/components/account/Portfolio/PortfolioPage.tsx
+++ b/src/components/account/Portfolio/PortfolioPage.tsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
 import { Shimmer } from '../../common/shimmer/Shimmer';
 import { usePageTitle } from '../../common/usePageTitle';
-import { useSavingsFundBalance, useSourceFunds } from '../../common/apiHooks';
+import { useMe, useSavingsFundBalance, useSourceFunds } from '../../common/apiHooks';
 import { currentValueByGroup } from '../../common/balances';
 import { usePortfolio } from './api/portfolio.api';
 import { PeriodSelector } from './PeriodSelector';
@@ -23,11 +23,21 @@ export const PortfolioPage: React.FunctionComponent = () => {
   // Prices rebuild a value out of units, and money the register has not turned into units
   // yet has none. For a period that runs to today the register itself can be asked, so the
   // closing value is the one the account page shows rather than one short of it.
-  const { data: sourceFunds } = useSourceFunds();
-  const { data: savingsFundBalance } = useSavingsFundBalance();
+  //
+  // A legal entity never holds a pillar, so it is not asked about one — the same request
+  // the represented-party account page leaves out for a company.
+  const { data: user } = useMe();
+  const holdsPillars = user !== undefined && user.role.type !== 'LEGAL_ENTITY';
+  const pensionBalance = useSourceFunds(undefined, undefined, { enabled: holdsPillars });
+  const savingsBalance = useSavingsFundBalance();
+
+  // Half an answer is worse than none: a balance for one band beside a rebuilt value for
+  // another adds up to a total from neither source, and nothing on the page would say so.
+  const registerAnswered =
+    (holdsPillars ? pensionBalance.isSuccess : user !== undefined) && savingsBalance.isSuccess;
   const currentValues =
-    period.to === moment().format('YYYY-MM-DD')
-      ? currentValueByGroup(sourceFunds, savingsFundBalance)
+    period.to === moment().format('YYYY-MM-DD') && registerAnswered
+      ? currentValueByGroup(pensionBalance.data, savingsBalance.data)
       : undefined;
 
   const onPeriodChange = useCallback((from: string | undefined, to: string) => {

--- a/src/components/account/Portfolio/PortfolioPage.tsx
+++ b/src/components/account/Portfolio/PortfolioPage.tsx
@@ -3,6 +3,8 @@ import moment from 'moment';
 import { FormattedMessage } from 'react-intl';
 import { Shimmer } from '../../common/shimmer/Shimmer';
 import { usePageTitle } from '../../common/usePageTitle';
+import { useSavingsFundBalance, useSourceFunds } from '../../common/apiHooks';
+import { currentValueByGroup } from '../../common/balances';
 import { usePortfolio } from './api/portfolio.api';
 import { PeriodSelector } from './PeriodSelector';
 import { PortfolioView } from './PortfolioView';
@@ -17,6 +19,16 @@ export const PortfolioPage: React.FunctionComponent = () => {
   });
 
   const { data: portfolio, isLoading, isError, refetch } = usePortfolio(period.from, period.to);
+
+  // Prices rebuild a value out of units, and money the register has not turned into units
+  // yet has none. For a period that runs to today the register itself can be asked, so the
+  // closing value is the one the account page shows rather than one short of it.
+  const { data: sourceFunds } = useSourceFunds();
+  const { data: savingsFundBalance } = useSavingsFundBalance();
+  const currentValues =
+    period.to === moment().format('YYYY-MM-DD')
+      ? currentValueByGroup(sourceFunds, savingsFundBalance)
+      : undefined;
 
   const onPeriodChange = useCallback((from: string | undefined, to: string) => {
     setPeriod({ from, to });
@@ -49,6 +61,7 @@ export const PortfolioPage: React.FunctionComponent = () => {
           portfolio={portfolio}
           from={period.from}
           to={period.to}
+          currentValues={currentValues}
           onPeriodChange={onPeriodChange}
         />
       ) : (

--- a/src/components/account/Portfolio/PortfolioView.test.tsx
+++ b/src/components/account/Portfolio/PortfolioView.test.tsx
@@ -338,6 +338,55 @@ describe('the balance the register holds today', () => {
   });
 });
 
+describe('the day the money is counted on', () => {
+  const renderTo = (
+    value: Portfolio,
+    to: string,
+    currentValues?: Partial<Record<PortfolioGroup, number>>,
+  ) =>
+    renderWrapped(
+      <PortfolioView
+        portfolio={value}
+        from="2025-01-01"
+        to={to}
+        currentValues={currentValues}
+        onPeriodChange={() => {}}
+      />,
+    );
+
+  const endingBefore = portfolio({
+    series: [
+      { date: '2025-01-01', values: { SAVINGS_FUND: 100 } },
+      { date: '2025-12-28', values: { SAVINGS_FUND: 200 } },
+    ],
+  });
+
+  it('is the last day with a price when that is all the value rests on', () => {
+    renderTo(endingBefore, '2025-12-31');
+
+    expect(screen.getByRole('heading', { name: /28\.12\.2025/ })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /31\.12\.2025/ })).not.toBeInTheDocument();
+  });
+
+  it('is the end of the period once the register has been asked', () => {
+    renderTo(endingBefore, '2025-12-31', { SAVINGS_FUND: 250 });
+
+    expect(screen.getByRole('heading', { name: /31\.12\.2025/ })).toBeInTheDocument();
+  });
+
+  it('says where the chart stops when the balance is newer than the prices', () => {
+    renderTo(endingBefore, '2025-12-31', { SAVINGS_FUND: 250 });
+
+    expect(screen.getByText(/chart ends on 28\.12\.2025/i)).toBeInTheDocument();
+  });
+
+  it('says nothing about the chart when it already runs to the end of the period', () => {
+    renderTo(portfolio(), '2025-12-31', { SAVINGS_FUND: 250 });
+
+    expect(screen.queryByText(/chart ends on/i)).not.toBeInTheDocument();
+  });
+});
+
 describe('the period someone types into the date inputs', () => {
   const renderWithPeriodChange = (onPeriodChange: (from?: string, to?: string) => void) =>
     renderWrapped(

--- a/src/components/account/Portfolio/PortfolioView.test.tsx
+++ b/src/components/account/Portfolio/PortfolioView.test.tsx
@@ -261,6 +261,83 @@ describe('the portfolio the backend valued', () => {
   });
 });
 
+describe('the balance the register holds today', () => {
+  const renderWithBalances = (
+    value: Portfolio,
+    currentValues: Partial<Record<PortfolioGroup, number>>,
+  ) =>
+    renderWrapped(
+      <PortfolioView
+        portfolio={value}
+        from="2025-01-01"
+        to="2025-12-31"
+        currentValues={currentValues}
+        onPeriodChange={() => {}}
+      />,
+    );
+
+  it('is shown instead of the value rebuilt from transactions', () => {
+    renderWithBalances(portfolio(), { SAVINGS_FUND: 250 });
+
+    expect(screen.getAllByText(/250[.,]00/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/200[.,]00/)).not.toBeInTheDocument();
+  });
+
+  it('counts the money the register has not turned into units into the growth', () => {
+    renderWithBalances(portfolio(), { SAVINGS_FUND: 260 });
+
+    // 260 closing + 0 withdrawn − 100 opening − 50 paid in
+    expect(screen.getByText(/110[.,]00/)).toBeInTheDocument();
+  });
+
+  it('leaves a band the register says nothing about on its rebuilt value', () => {
+    renderWithBalances(
+      portfolio({
+        groups: [
+          summary('SAVINGS_FUND', { endValue: 200 }),
+          summary('SECOND_PILLAR', { endValue: 300 }),
+        ],
+        series: [
+          { date: '2025-01-01', values: { SAVINGS_FUND: 100, SECOND_PILLAR: 200 } },
+          { date: '2025-12-31', values: { SAVINGS_FUND: 200, SECOND_PILLAR: 300 } },
+        ],
+      }),
+      { SECOND_PILLAR: 350 },
+    );
+
+    expect(screen.getAllByText(/550[.,]00/).length).toBeGreaterThan(0);
+  });
+
+  it('values a band the prices could not value at what the register holds', () => {
+    renderWithBalances(portfolio({ groups: [summary('SAVINGS_FUND', { endValue: null })] }), {
+      SAVINGS_FUND: 250,
+    });
+
+    expect(screen.getAllByText(/250[.,]00/).length).toBeGreaterThan(0);
+  });
+
+  it('drops a band switched off from the balance as well', () => {
+    renderWithBalances(
+      portfolio({
+        groups: [
+          summary('SAVINGS_FUND', { endValue: 200 }),
+          summary('SECOND_PILLAR', { endValue: 300 }),
+        ],
+        series: [
+          { date: '2025-01-01', values: { SAVINGS_FUND: 100, SECOND_PILLAR: 200 } },
+          { date: '2025-12-31', values: { SAVINGS_FUND: 200, SECOND_PILLAR: 300 } },
+        ],
+      }),
+      { SAVINGS_FUND: 250, SECOND_PILLAR: 350 },
+    );
+
+    userEvent.click(screen.getByRole('button', { name: /Täiendav Kogumisfond/ }));
+
+    expect(screen.getAllByText(/350[.,]00/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/600[.,]00/)).not.toBeInTheDocument();
+  });
+});
+
 describe('the period someone types into the date inputs', () => {
   const renderWithPeriodChange = (onPeriodChange: (from?: string, to?: string) => void) =>
     renderWrapped(

--- a/src/components/account/Portfolio/PortfolioView.tsx
+++ b/src/components/account/Portfolio/PortfolioView.tsx
@@ -50,22 +50,44 @@ const Amount: React.FunctionComponent<{ value: number | null }> = ({ value }) =>
     <Euro amount={value} />
   );
 
+// The register holds money it has not turned into units yet, and a value rebuilt from
+// units alone cannot see it. Where the register has spoken for a group, its balance is
+// what the account page shows — so it is what this page shows too, and the gain is
+// restated around it rather than left describing a closing value nobody is looking at.
+const withCurrentValue = (
+  summary: PortfolioGroupSummary,
+  currentValue: number | undefined,
+): PortfolioGroupSummary => {
+  if (currentValue === undefined) {
+    return summary;
+  }
+  const { startValue, contributions, withdrawals } = summary;
+  return {
+    ...summary,
+    endValue: currentValue,
+    gain: startValue === null ? null : currentValue + withdrawals - startValue - contributions,
+  };
+};
+
 export const PortfolioView: React.FunctionComponent<{
   portfolio: Portfolio;
   from: string | undefined;
   to: string;
+  currentValues?: Partial<Record<PortfolioGroup, number>>;
   onPeriodChange: (from: string | undefined, to: string) => void;
-}> = ({ portfolio, from, to, onPeriodChange }) => {
-  const available = GROUPS.filter(({ id }) =>
-    portfolio.groups.some((summary) => summary.group === id),
+}> = ({ portfolio, from, to, currentValues, onPeriodChange }) => {
+  const groups = portfolio.groups.map((summary) =>
+    withCurrentValue(summary, currentValues?.[summary.group]),
   );
+
+  const available = GROUPS.filter(({ id }) => groups.some((summary) => summary.group === id));
 
   // Everything the person holds is shown until they switch a band off, so someone with
   // no savings fund still lands on their own pillars instead of an empty chart.
   const [hidden, setHidden] = useState<PortfolioGroup[]>([]);
   const visible = available.filter(({ id }) => !hidden.includes(id));
 
-  const visibleSummaries = portfolio.groups.filter((summary) =>
+  const visibleSummaries = groups.filter((summary) =>
     visible.some(({ id }) => id === summary.group),
   );
 

--- a/src/components/account/Portfolio/PortfolioView.tsx
+++ b/src/components/account/Portfolio/PortfolioView.tsx
@@ -123,23 +123,25 @@ export const PortfolioView: React.FunctionComponent<{
         />
 
         {available.length > 1 && (
-          <div className="d-flex flex-wrap gap-2 align-items-center mt-3 pt-3 border-top">
+          <div className="d-flex flex-column flex-sm-row flex-wrap align-items-start align-items-sm-center gap-2 mt-3 pt-3 border-top">
             <span className="text-body-secondary me-1">
               <FormattedMessage id="savingsFund.statement.show" />
             </span>
             {/* The last band still showing cannot be switched off: an empty selection would
                 sum to nothing and present the person's money as 0 €. */}
-            {available.map(({ id, label }) => (
-              <PillButton
-                key={id}
-                selected={!hidden.includes(id)}
-                pressed={!hidden.includes(id)}
-                disabled={visible.length === 1 && !hidden.includes(id)}
-                onClick={() => toggle(id)}
-              >
-                <FormattedMessage id={label} />
-              </PillButton>
-            ))}
+            <div className="d-flex flex-wrap gap-2">
+              {available.map(({ id, label }) => (
+                <PillButton
+                  key={id}
+                  selected={!hidden.includes(id)}
+                  pressed={!hidden.includes(id)}
+                  disabled={visible.length === 1 && !hidden.includes(id)}
+                  onClick={() => toggle(id)}
+                >
+                  <FormattedMessage id={label} />
+                </PillButton>
+              ))}
+            </div>
           </div>
         )}
       </div>

--- a/src/components/account/Portfolio/PortfolioView.tsx
+++ b/src/components/account/Portfolio/PortfolioView.tsx
@@ -107,6 +107,14 @@ export const PortfolioView: React.FunctionComponent<{
     visible.map(({ id }) => id),
   );
 
+  // Prices are published a day or more behind, so the last point drawn is not always the
+  // end of the period. The heading names the day the money on it was actually counted:
+  // the register's own day when it answered, otherwise the last day with a price.
+  const lastPricedDay = series.length > 0 ? series[series.length - 1].date : undefined;
+  const askedTheRegister = visible.some(({ id }) => currentValues?.[id] !== undefined);
+  const valuedAt = askedTheRegister ? to : lastPricedDay ?? to;
+  const chartStopsEarlier = lastPricedDay !== undefined && lastPricedDay < valuedAt;
+
   const toggle = (id: PortfolioGroup) =>
     setHidden((current) =>
       current.includes(id) ? current.filter((item) => item !== id) : [...current, id],
@@ -150,7 +158,7 @@ export const PortfolioView: React.FunctionComponent<{
         <h2 className="h6 text-body-secondary mb-2">
           <FormattedMessage
             id="savingsFund.statement.money.heading"
-            values={{ date: moment(to).format('DD.MM.YYYY') }}
+            values={{ date: moment(valuedAt).format('DD.MM.YYYY') }}
           />
         </h2>
         <div className="display-6 fw-medium text-navy">
@@ -198,6 +206,16 @@ export const PortfolioView: React.FunctionComponent<{
               <span>{moment(series[0].date).format('DD.MM.YYYY')}</span>
               <span>{moment(series[series.length - 1].date).format('DD.MM.YYYY')}</span>
             </div>
+          )}
+          {/* Otherwise the chart simply ends lower than the number above it, and nothing
+              on the page says why. */}
+          {chartStopsEarlier && series.length > 1 && (
+            <p className="text-body-tertiary small mt-1 mb-0">
+              <FormattedMessage
+                id="savingsFund.statement.money.chartEndsAt"
+                values={{ date: moment(lastPricedDay).format('DD.MM.YYYY') }}
+              />
+            </p>
           )}
           {visible.length > 1 && (
             <div className="d-flex flex-wrap gap-3 mt-2 small">

--- a/src/components/common/balances.ts
+++ b/src/components/common/balances.ts
@@ -1,0 +1,32 @@
+import { PortfolioGroup, SourceFund } from './apiModels';
+
+// What someone holds is their units plus the money the register has taken in but not
+// turned into units yet. Leaving the second half out understates the balance, so every
+// place that answers "how much do I have" adds both.
+export const pillarBalance = (sourceFunds: SourceFund[], pillar: 2 | 3): number =>
+  sourceFunds
+    .filter((fund) => fund.pillar === pillar)
+    .reduce((sum, fund) => sum + fund.price + fund.unavailablePrice, 0);
+
+export const fundBalance = (fund: SourceFund): number => fund.price + fund.unavailablePrice;
+
+// A group the register said nothing about is left out rather than reported as nothing:
+// a statement that has not arrived is not a balance of zero.
+export const currentValueByGroup = (
+  sourceFunds: SourceFund[] | undefined,
+  savingsFundBalance: SourceFund | null | undefined,
+): Partial<Record<PortfolioGroup, number>> => {
+  const values: Partial<Record<PortfolioGroup, number>> = {};
+
+  ([2, 3] as const).forEach((pillar) => {
+    if (sourceFunds?.some((fund) => fund.pillar === pillar)) {
+      values[pillar === 2 ? 'SECOND_PILLAR' : 'THIRD_PILLAR'] = pillarBalance(sourceFunds, pillar);
+    }
+  });
+
+  if (savingsFundBalance) {
+    values.SAVINGS_FUND = fundBalance(savingsFundBalance);
+  }
+
+  return values;
+};

--- a/src/components/pensionCalculator/PensionCalculator.tsx
+++ b/src/components/pensionCalculator/PensionCalculator.tsx
@@ -32,7 +32,7 @@ import {
   useSourceFunds,
   useTransactions,
 } from '../common/apiHooks';
-import { SourceFund } from '../common/apiModels';
+import { pillarBalance } from '../common/balances';
 import {
   deriveFeeBounds,
   deriveGrossSalary,
@@ -162,13 +162,6 @@ const signedPercent = (value: number): string => {
   const sign = value > 0 ? '+' : '−';
   return `${sign}${Math.abs(value)}%`;
 };
-
-const pillarBalance = (sourceFunds: SourceFund[], pillar: 2 | 3): number =>
-  Math.round(
-    sourceFunds
-      .filter((fund) => fund.pillar === pillar)
-      .reduce((sum, fund) => sum + fund.price + fund.unavailablePrice, 0),
-  );
 
 // Draws the dashed vertical marker lines: "you are here" between the recorded past
 // and the projection, and "you retire here". Chart.js has no annotation support
@@ -410,13 +403,13 @@ export const PensionCalculator: React.FC = () => {
         secondPillarRate: user.secondPillarActive
           ? user.secondPillarPaymentRates?.pending ?? user.secondPillarPaymentRates?.current ?? 2
           : 0,
-        secondPillarBalance: pillarBalance(sourceFunds, 2),
+        secondPillarBalance: Math.round(pillarBalance(sourceFunds, 2)),
         // Capped at the tax-advantaged ceiling — the slider never exceeds it either.
         thirdPillarMonthly: Math.min(
           deriveThirdPillarMonthly(contributions, now),
           thirdPillarTaxCapMonthly(deriveGrossSalary(contributions, now) ?? DEFAULT_GROSS_SALARY),
         ),
-        thirdPillarBalance: pillarBalance(sourceFunds, 3),
+        thirdPillarBalance: Math.round(pillarBalance(sourceFunds, 3)),
         // Only unit holders get the slider, so only they get a prefill: projecting a
         // standing order behind a hidden control would bake in money the saver can
         // neither see nor turn off (e.g. after emptying the account).

--- a/src/components/translations/translations.en.json
+++ b/src/components/translations/translations.en.json
@@ -1280,6 +1280,7 @@
   "savingsFund.statement.money.annualReturnUnavailable": "Annual return is shown one selection at a time (II or III pillar).",
   "savingsFund.statement.money.unvaluable": "We do not have a price for part of your holdings right now, so we cannot show what this is worth. Please try again later.",
   "savingsFund.statement.money.unknown": "Not known",
+  "savingsFund.statement.money.chartEndsAt": "The chart ends on {date}, the last day fund prices are known for.",
   "savingsFund.statement.period.label": "Period",
   "savingsFund.statement.period.thisYear": "This year",
   "savingsFund.statement.period.lastYear": "Last year",

--- a/src/components/translations/translations.et.json
+++ b/src/components/translations/translations.et.json
@@ -1370,6 +1370,7 @@
   "savingsFund.statement.money.annualReturnUnavailable": "Aastast tootlust näitame ühe valiku kaupa (II või III sammas).",
   "savingsFund.statement.money.unvaluable": "Osale sinu varast puudub praegu hind, seega me ei saa näidata, kui palju see väärt on. Palun proovi hiljem uuesti.",
   "savingsFund.statement.money.unknown": "Pole teada",
+  "savingsFund.statement.money.chartEndsAt": "Graafik lõpeb {date} – viimane päev, mille kohta fondide hinnad on teada.",
   "savingsFund.statement.period.label": "Periood",
   "savingsFund.statement.period.thisYear": "See aasta",
   "savingsFund.statement.period.lastYear": "Eelmine aasta",


### PR DESCRIPTION
## What

The portfolio page disagreed with the account page about how much someone has, by a few percent, on the same day.

It was the only "how much do I have" surface in the app that did not read the balance API. It rebuilt a value from cash-flow transactions multiplied by NAV history, while the account page, `/calculator`, the millionaire calculator and the 1st-vs-2nd comparison all sum `price + unavailablePrice`. Money the register has taken in but not yet turned into units has no units, so the rebuilt value could not see it.

For a period that runs to today the register is now asked directly, so the closing value is the one every other page shows.

## Commits

1. **Move the pillar balance sum where every page can share it** — pure refactor, no behaviour change. `price + unavailablePrice` moves into `common/balances.ts`; `/calculator` imports it and keeps its own rounding at the call site.
2. **Show what the register holds as the portfolio's closing value** — the change above.
3. **Let the period and band pills wrap as a group on a phone** — layout only.
4. **Take the register's word only when the whole of it has arrived** — two fixes from an independent review, below.
5. **Name the day the money on the heading was counted** — the heading claimed the end of the period even when the value rested on an older published price.

## Decisions a reviewer would otherwise have to ask about

**`useSourceFunds()` is deliberately called with no dates.** `EpisService.getAccountStatement` is `@Cacheable` under `condition = "#fromDate == null && #toDate == null"`. Passing period dates would defeat that condition and send every portfolio page view to EPIS.

**`common/balances.ts` rather than a feature-colocated helper.** Two pages must not be able to drift on this arithmetic — that drift is the bug being fixed. Open to moving it if you would rather it lived elsewhere.

**The gain line now mixes two sources.** `endValue` comes from the register, `contributions` from the backend's cash flows, and they have different lag. A payment the register has booked but the cash-flow statement does not yet list shows up as growth for a few days, until the units are issued. Bounded by money in flight, and it self-corrects. The alternative — leaving the gain as the backend computed it — makes the formula printed under the tiles visibly not add up.

**The annual return rate is left as the backend computed it.** XIRR is over invested units; cash the register holds but has not invested earns nothing, so leaving it out of a *rate* is the more defensible basis.

## From an independent (Codex) review of commit 2

- **Partial register answers were being mixed in.** The savings-balance API swallows failures into `null`, so a failed savings call left the page adding a register value for one band to a rebuilt value for another — a total from neither source, with nothing on screen saying so. It now waits for the whole answer before overriding anything.
- **Companies were being asked about pillars.** `RepresentedPartyAccountPage` deliberately skips `/v1/pension-account-statement` for a legal entity; this page asked anyway. Now gated the same way. (The backend already short-circuits it, so this was a pointless round-trip rather than load.)

## Performance

No new backend queries. Two extra client requests on `/portfolio`, both already cached server-side, and one of them is now skipped entirely for a company.

## Merge order

Pairs with onboarding-service#1843, which stops the chart opening in 2003. Neither depends on the other; the chart start only changes once the service side deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)